### PR TITLE
Issue #8 -wrong return type for Set->sortedBy() and OrderedSet->sortBy()

### DIFF
--- a/use-core/src/main/java/org/tzi/use/uml/ocl/expr/ExpQuery.java
+++ b/use-core/src/main/java/org/tzi/use/uml/ocl/expr/ExpQuery.java
@@ -21,25 +21,13 @@
 
 package org.tzi.use.uml.ocl.expr;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashSet;
-import java.util.List;
-import java.util.ListIterator;
-import java.util.Set;
-
 import org.tzi.use.uml.ocl.type.CollectionType;
 import org.tzi.use.uml.ocl.type.Type;
 import org.tzi.use.uml.ocl.type.Type.VoidHandling;
 import org.tzi.use.uml.ocl.type.TypeFactory;
-import org.tzi.use.uml.ocl.value.BagValue;
-import org.tzi.use.uml.ocl.value.BooleanValue;
-import org.tzi.use.uml.ocl.value.CollectionValue;
-import org.tzi.use.uml.ocl.value.SequenceValue;
-import org.tzi.use.uml.ocl.value.UndefinedValue;
-import org.tzi.use.uml.ocl.value.Value;
+import org.tzi.use.uml.ocl.value.*;
+
+import java.util.*;
 
 /**
  * Abstract base class for select, reject, collect, exists, forAll and iterate
@@ -471,7 +459,12 @@ public abstract class ExpQuery extends Expression {
         }
 
         Type rangeElemType = ((CollectionType) fRangeExp.type()).elemType();
-        return new SequenceValue(rangeElemType, result);
+
+        if (this.type().isTypeOfOrderedSet()) {
+            return new OrderedSetValue(rangeElemType, result);
+        } else {
+            return new SequenceValue(rangeElemType, result);
+        }
     }
 
     // used by evalSortedBy

--- a/use-core/src/main/java/org/tzi/use/uml/ocl/expr/ExpSortedBy.java
+++ b/use-core/src/main/java/org/tzi/use/uml/ocl/expr/ExpSortedBy.java
@@ -44,7 +44,7 @@ public class ExpSortedBy extends ExpQuery {
         throws ExpInvalidException
     {
         // result type is sequence of range element type
-        super(TypeFactory.mkSequence(((CollectionType) rangeExp.type()).elemType()),
+        super(determineType(rangeExp),
               ( elemVarDecl != null ) 
               ? new VarDeclList(elemVarDecl) 
               : new VarDeclList(true),
@@ -57,6 +57,21 @@ public class ExpSortedBy extends ExpQuery {
                                           "Argument of sortedBy must have basic type " +
                                           "(Integer, Real, or String), found `" + 
                                           queryExp.type() + "'.");
+    }
+
+    /**
+     * Helper method to make the constructor more readable.
+     * That's it.
+     * @param rangeExp The <code>Expression</code> the <code>sortedBy</code> is applied to.
+     * @return The resulting <code>Type</code> of this operation. <code>OrderedSet</code> when called on
+     *         an <code>OrderedSet</code> or a <code>Set</code>, <code>Sequence</code> otherwise.
+     */
+    private static Type determineType(Expression rangeExp) {
+        if (rangeExp.type().isTypeOfOrderedSet() || rangeExp.type().isTypeOfSet()) {
+            return TypeFactory.mkOrderedSet(((CollectionType) rangeExp.type()).elemType());
+        } else {
+            return TypeFactory.mkSequence(((CollectionType) rangeExp.type()).elemType());
+        }
     }
 
     /** 

--- a/use-core/src/test/resources/org/tzi/use/parser/test_expr.in
+++ b/use-core/src/test/resources/org/tzi/use/parser/test_expr.in
@@ -516,4 +516,11 @@ Sequence{2,4,6,3}->iterate(
   )
 -> Sequence{2,3,4,6} : Sequence(Integer)
 
-
+# Wrong return type for Set->sortedBy() and OrderedSet->sortBy()
+# https://github.com/useocl/use/issues/8
+?Set{-2..3}->sortedBy(I|I*I)
+-> Sequence{0,-1,1,-2,2,3} : Sequence(Integer)
+?OrderedSet{-2..3}->sortedBy(I|I*I)
+-> Sequence{0,-1,1,-2,2,3} : Sequence(Integer)
+let c:Collection(Integer) = Set{-2..3} in c->sortedBy(I|I*I)
+-> Sequence{0,-1,1,-2,2,3} : Sequence(Integer)


### PR DESCRIPTION
- Type of sortedBy is now calculated conforming the OCL standard
- Added tests for all collection types
- Closes #8 