### PR TITLE
Dependency Security Update

### DIFF
--- a/use-core/pom.xml
+++ b/use-core/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>20.0</version>
+            <version>[30.0-jre,)</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jdt</groupId>


### PR DESCRIPTION
- Update to guava 30.0 and newer, because of a security issue