### PR TITLE
Fixed Module Dependencies

### DIFF
--- a/use-gui/pom.xml
+++ b/use-gui/pom.xml
@@ -26,6 +26,12 @@
             <groupId>xerces</groupId>
             <artifactId>xercesImpl</artifactId>
             <version>2.12.2</version>
+            <exclusions>
+            	<exclusion>
+            		<groupId>xml-apis</groupId>
+            		<artifactId>xml-apis</artifactId>
+            	</exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
Excluded xml-apis in dependency xerces because it breaks the 'new' Java
Module System.

See: https://stackoverflow.com/questions/55571046/eclipse-is-confused-by-imports-accessible-from-more-than-one-module