### PR TITLE
Resolve build errors on linux

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -3,11 +3,7 @@
 
 name: Java CI with Maven
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: push
 
 jobs:
   build:

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>org.tzi.use</groupId>
     <artifactId>use</artifactId>
     <packaging>pom</packaging>
-    <version>7.0.1</version>
+    <version>7.1.0</version>
     <modules>
         <module>use-core</module>
         <module>use-gui</module>

--- a/use-assembly/pom.xml
+++ b/use-assembly/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>use</artifactId>
         <groupId>org.tzi.use</groupId>
-        <version>7.0.1</version>
+        <version>7.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/use-core/pom.xml
+++ b/use-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>use</artifactId>
         <groupId>org.tzi.use</groupId>
-        <version>7.0.1</version>
+        <version>7.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/use-core/src/main/java/org/tzi/use/config/Options.java
+++ b/use-core/src/main/java/org/tzi/use/config/Options.java
@@ -46,7 +46,7 @@ import java.util.prefs.Preferences;
 public class Options {
 
     // the release version
-    public static final String RELEASE_VERSION = "7.0.1";
+    public static final String RELEASE_VERSION = "7.1.0";
 
     // the copyright
     public static final String COPYRIGHT = "Copyright (C) 1999-2021 University of Bremen";

--- a/use-gui/pom.xml
+++ b/use-gui/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>use</artifactId>
         <groupId>org.tzi.use</groupId>
-        <version>7.0.1</version>
+        <version>7.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/use-gui/src/it/java/org/tzi/use/main/ShellIT.java
+++ b/use-gui/src/it/java/org/tzi/use/main/ShellIT.java
@@ -5,7 +5,6 @@ import com.github.difflib.patch.AbstractDelta;
 import com.github.difflib.patch.Patch;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.TestFactory;
-import org.tzi.use.config.Options;
 
 import java.io.*;
 import java.net.URISyntaxException;
@@ -210,7 +209,7 @@ public class ShellIT {
 
                     try {
                         cmdWriter.write(inputLine);
-                        cmdWriter.write(Options.LINE_SEPARATOR);
+                        cmdWriter.write(System.lineSeparator());
 
                         expectedOutput.add((prompt + inputLine).trim());
                     } catch (IOException e1) {

--- a/use-gui/src/it/java/org/tzi/use/main/ShellIT.java
+++ b/use-gui/src/it/java/org/tzi/use/main/ShellIT.java
@@ -145,7 +145,14 @@ public class ShellIT {
 
             //simple output the computed patch to console
             for (AbstractDelta<String> delta : patch.getDeltas()) {
-                diffMsg.append(delta.toString()).append(System.lineSeparator());
+                diffMsg.append("Diff [")
+                        .append(delta.getType())
+                        .append("] Source: '")
+                        .append(delta.getSource().toString())
+                        .append("' Target: '" )
+                        .append(delta.getTarget().toString())
+                        .append("'")
+                        .append(System.lineSeparator());
             }
 
             writeToFile(expectedOutput, testFile.getParent().resolve(testFile.getFileName().toString() + ".expected" ));

--- a/use-gui/src/it/java/org/tzi/use/main/ShellIT.java
+++ b/use-gui/src/it/java/org/tzi/use/main/ShellIT.java
@@ -134,8 +134,15 @@ public class ShellIT {
      */
     private void validateOutput(Path testFile, List<String> expectedOutput, List<String> actualOutput) {
         Patch<String> patch = DiffUtils.diff(expectedOutput, actualOutput);
+        boolean nonWhitespaceChange = false;
 
-        if (!patch.getDeltas().isEmpty()) {
+        // Check if non whitespace diffs are present
+        nonWhitespaceChange = patch.getDeltas().stream().anyMatch(
+                (delta) -> delta.getSource().getLines().stream().anyMatch(line -> !line.isBlank()) ||
+                           delta.getTarget().getLines().stream().anyMatch(line -> !line.isBlank())
+        );
+
+        if (nonWhitespaceChange) {
             StringBuilder diffMsg = new StringBuilder("USE output does not match expected output!").append(System.lineSeparator());
 
             diffMsg.append("Testfile: ").append(testFile).append(System.lineSeparator());
@@ -325,7 +332,9 @@ public class ShellIT {
 
             if (proc.isAlive()) {
                 line = line == null ? "" : line.trim();
-                actualOutput.add(line);
+                if (!line.equals("")) {
+                    actualOutput.add(line);
+                }
             }
         }
 


### PR DESCRIPTION
When run on linux, the integration tests failed because of additonal whitespaces.

In this PR the following changes have been implemented:

## Ignore whitespace-only diffs
If the expected and actual output of an integrationtest only differ in whitespace changes the test does not fail.

## Improved output of diffa
The output was somehow enriched with more detail

## Build on Linux
Pipeline is now run on linux. 