### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up JDK 15
       uses: actions/setup-java@v2
       with:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up JDK 15
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         java-version: '15'
         distribution: 'adopt'
@@ -22,7 +22,7 @@ jobs:
       run: mvn --batch-mode --update-snapshots verify
     - name: Upload build result
       run: mkdir staging && cp use-assembly/target/*.zip staging
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: Package
         path: staging

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,12 @@ jobs:
 
      steps:
        - name: Checkout
-         uses: actions/checkout@v2
+         uses: actions/checkout@v3
          with:
            fetch-depth: 0
 
        - name: Set up JDK
-         uses: actions/setup-java@v2
+         uses: actions/setup-java@v3
          with:
            java-version: '15'
            distribution: 'adopt'

--- a/documentation/documentation.md
+++ b/documentation/documentation.md
@@ -47,7 +47,7 @@ Checks out the commit that triggered the execution of the release process (the t
 
 #### 1.2 Setup JDK
 
-Sets the used JDK to the used version.
+Sets up a JDK with the used version (currently 15) by using [actions/setup-java@v3](https://github.com/actions/setup-java).
 
 #### 1.3 Maven Build
 
@@ -56,7 +56,7 @@ Executes a complete Maven build inclusing all tests and assemling an archive.
 #### 1.4 Create Release
 
 Creates a new GitHub release that is accessible from the project page.
-This is done using this [release action](https://github.com/ncipollo/release-action).
+This is done using [release-action](https://github.com/ncipollo/release-action).
 
 #### 1.5 Create Bump Version Issue
 

--- a/documentation/documentation.md
+++ b/documentation/documentation.md
@@ -43,7 +43,7 @@ This is the only job of the release action, because all steps depend on the succ
 
 #### 1.1 Checkout
 
-Checks out the commit that triggered the execution of the release process (the tag).
+Checks out the commit that triggered the execution of the release process (the tag) using [actions/checkout](https://github.com/actions/checkout).
 
 #### 1.2 Setup JDK
 


### PR DESCRIPTION
GitHub deactivated actions depending on node.js 12.
Updated action version for the basic actions checkout, setup-java, upload-artifact.

Release actions might contain old dependencies. Need to be checked.