### PR TITLE
fix!: UseModelApi: Lacks of self for attributes in OCL Expression

### DIFF
--- a/use-core/src/main/java/org/tzi/use/api/UseModelApi.java
+++ b/use-core/src/main/java/org/tzi/use/api/UseModelApi.java
@@ -18,10 +18,13 @@
  */
 package org.tzi.use.api;
 
-import org.tzi.use.parser.Context;
-import org.tzi.use.parser.SemanticException;
-import org.tzi.use.parser.SrcPos;
-import org.tzi.use.parser.Symtable;
+import org.antlr.runtime.ANTLRInputStream;
+import org.antlr.runtime.CommonTokenStream;
+import org.antlr.runtime.RecognitionException;
+import org.tzi.use.parser.*;
+import org.tzi.use.parser.generator.GeneratorLexer;
+import org.tzi.use.parser.generator.GeneratorParser;
+import org.tzi.use.parser.ocl.ASTExpression;
 import org.tzi.use.parser.ocl.OCLCompiler;
 import org.tzi.use.parser.soil.SoilCompiler;
 import org.tzi.use.parser.soil.ast.ASTStatement;
@@ -41,10 +44,7 @@ import org.tzi.use.util.NullPrintWriter;
 import org.tzi.use.util.StringUtil;
 import org.tzi.use.util.soil.exceptions.CompilationFailedException;
 
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-import java.io.PrintWriter;
-import java.io.StringWriter;
+import java.io.*;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -498,7 +498,7 @@ public class UseModelApi {
 	 * @param condition The OCL-Expression of the condition.
 	 * @param isPre Switch whether the condition is a precondition or not.
 	 * @return The created {@link MPrePostCondition}.
-	 * @throws UseApiException
+	 * @throws UseApiException If the condition could not be created.
 	 */
 	public MPrePostCondition createPrePostCondition(String ownerName,
 			String operationName, String name, String condition, boolean isPre)
@@ -506,7 +506,7 @@ public class UseModelApi {
 		MClass cls = getClassSafe(ownerName);
 		MOperation op = cls.operation(operationName, false);
 
-		if(op == null){
+		if(op == null) {
 			throw new UseApiException("Unknown operation "
 					+ StringUtil.inQuotes(ownerName + "::" + operationName)
 					+ ".");
@@ -515,30 +515,51 @@ public class UseModelApi {
 		StringWriter errBuffer = new StringWriter();
 		PrintWriter errorPrinter = new PrintWriter(errBuffer, true);
 
-		Symtable symTable = new Symtable();
+		ParseErrorHandler errHandler = new ParseErrorHandler("UseModelApi", errorPrinter);
+		InputStream inStream = new ByteArrayInputStream(condition.getBytes());
+
+		Expression exp = null;
+
 		try {
-			symTable.add("self", cls, null);
-			for(VarDecl var : op.paramList()){
-				symTable.add(var.name(), var.type(), null);
+			ANTLRInputStream aInput = new ANTLRInputStream(inStream);
+			aInput.name = "UseModelApi";
+
+			GeneratorLexer lexer = new GeneratorLexer(aInput);
+			CommonTokenStream tStream = new CommonTokenStream(lexer);
+			GeneratorParser parser = new GeneratorParser(tStream);
+
+			lexer.init(errHandler);
+			parser.init(errHandler);
+
+			// Parse the specification
+			ASTExpression astCondition = parser.expressionOnly();
+
+			if (errHandler.errorCount() == 0 ) {
+				ModelFactory modelFactory = new ModelFactory();
+				Context ctx = new Context("UseModelApi",
+						errorPrinter,
+						null,
+						modelFactory);
+				ctx.setModel(this.getModel());
+
+				Symtable vars = ctx.varTable();
+
+				// create pseudo-variable "self"
+				vars.add("self", cls, null);
+				ctx.exprContext().push("self", cls);
+				// add special variable `result' in postconditions with result value
+				if (! isPre && op.hasResultType() )
+					vars.add("result", op.resultType(), null);
+
+				ctx.setInsidePostCondition(! isPre);
+
+				exp = astCondition.gen(ctx);
 			}
-			if(op.hasResultType()){
-				symTable.add("result", op.resultType(), null);
-			}
-		}
-		catch(SemanticException ex){
-			throw new UseApiException("Could not create pre-/postcondition.", ex);
-		}
+		} catch (RecognitionException | SemanticException | IOException e) {
+            throw new UseApiException("Error adding condition!", e);
+        }
 
-		Expression conditionExp = OCLCompiler.compileExpression(mModel,
-				condition, "condition", errorPrinter, symTable);
-
-		if (conditionExp == null) {
-			throw new UseApiException(
-					"Compilation of condition expression failed:\n"
-							+ errBuffer.toString());
-		}
-
-		return createPrePostConditionEx(name, op, isPre, conditionExp);
+		return this.createPrePostConditionEx(name, op,isPre, exp);
 	}
 
 	/**

--- a/use-core/src/test/java/org/tzi/use/uml/mm/ModelAPITest.java
+++ b/use-core/src/test/java/org/tzi/use/uml/mm/ModelAPITest.java
@@ -1,0 +1,35 @@
+package org.tzi.use.uml.mm;
+
+import org.junit.jupiter.api.Test;
+import org.tzi.use.api.UseApiException;
+import org.tzi.use.api.UseModelApi;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ModelAPITest {
+    @Test
+    public void testConstraintCreation() throws UseApiException {
+        UseModelApi api = new UseModelApi("UnitTest");
+        MPrePostCondition ppc;
+
+        api.createClass("A", false);
+        api.createAttribute("A", "foo", "String");
+        api.createOperation("A", "bar", new String[0][0], "String");
+        ppc = api.createPrePostCondition("A", "bar", "self.foo is defined", "self.foo.isDefined()", true);
+        assertEquals("self.foo is defined", ppc.name());
+
+        ppc = api.createPrePostCondition("A", "bar", "foo without self is defined", "foo.isDefined()", true);
+        assertEquals("foo without self is defined", ppc.name());
+
+        assertEquals(2, api.getClass("A").operation("bar", true).preConditions().size());
+
+        api.createPrePostCondition("A", "bar", "result can be checked", "result.isDefined()", false);
+
+        assertEquals(1, api.getClass("A").operation("bar", true).postConditions().size());
+
+        Exception ex = assertThrows(UseApiException.class, ()
+                -> api.createPrePostCondition("B", "", "", "", true));
+
+        assertTrue(ex.getMessage().contains("Unknown"));
+    }
+}


### PR DESCRIPTION
- Now the correct context for pre and postconditions is created
- This includes the automatically provided variable  result for postconditions
- Code is similar to the code in ASTPrePostCondition