### PR TITLE
fix!: Postconditions of query oparations using result fail to evaluate

### DIFF
--- a/use-core/src/main/java/org/tzi/use/uml/ocl/expr/ExpObjOp.java
+++ b/use-core/src/main/java/org/tzi/use/uml/ocl/expr/ExpObjOp.java
@@ -19,8 +19,6 @@
 
 package org.tzi.use.uml.ocl.expr;
 
-import java.util.List;
-
 import org.tzi.use.uml.mm.MOperation;
 import org.tzi.use.uml.ocl.value.ObjectValue;
 import org.tzi.use.uml.ocl.value.UndefinedValue;
@@ -31,6 +29,8 @@ import org.tzi.use.uml.sys.MSystem;
 import org.tzi.use.uml.sys.MSystemException;
 import org.tzi.use.uml.sys.ppcHandling.ExpressionPPCHandler;
 import org.tzi.use.util.StringUtil;
+
+import java.util.List;
 
 /**
  * An operation defined by a class.
@@ -134,6 +134,7 @@ public final class ExpObjOp extends Expression {
     	
 			if (operation.hasExpression()) {
 				result = operation.expression().eval(ctx);
+				operationCall.setResultValue(result);
 			}
 
 			operationCall.setExecutionFailed(false);
@@ -142,7 +143,7 @@ public final class ExpObjOp extends Expression {
     	} finally {
     		try {
 	    		if (operationCall.enteredSuccessfully()) {
-	    			system.exitQueryOperation(ctx, result);
+	    			system.exitQueryOperation(ctx);
 	    		}
     		} catch (Exception e){ }
     		ctx.popVarBindings(fArgs.length);

--- a/use-core/src/main/java/org/tzi/use/uml/sys/MSystem.java
+++ b/use-core/src/main/java/org/tzi/use/uml/sys/MSystem.java
@@ -546,17 +546,15 @@ public final class MSystem {
 	}
 
 	/**
-	 * Exits a query operation, i. e., a query without side effects. Validates
-	 * the post conditions of the query expression.
+	 * <p>Exits a query operation, i.e., a query without side effects. Validates
+	 * the post conditions of the query expression.</p>
 	 * 
-	 * In any case, the operation is removed from the call stack.
+	 * <p>In any case, the operation is removed from the call stack.</p>
 	 * 
-	 * @param ctx
-	 * @param resultValue
-	 * @return
-	 * @throws MSystemException
+	 * @param ctx The <code>EvalContext</code> the operations is evaluated in.
+	 * @throws MSystemException If the call stack is empty.
 	 */
-	public MOperationCall exitQueryOperation(EvalContext ctx, Value resultValue) throws MSystemException {
+	public void exitQueryOperation(EvalContext ctx) throws MSystemException {
 
 		MOperationCall operationCall = getCurrentOperation();
 
@@ -567,7 +565,7 @@ public final class MSystem {
 		if (operationCall.executionHasFailed()) {
 			operationCall.setExited(true);
 			fCallStack.pop();
-			return operationCall;
+			return;
 		}
 
 		try {
@@ -575,8 +573,6 @@ public final class MSystem {
 				assertPostConditions(ctx, operationCall);
 
 			operationCall.setExitedSuccessfully(true);
-
-			return operationCall;
 		} finally {
 			operationCall.setExited(true);
 			fCallStack.pop();

--- a/use-gui/src/it/resources/testfiles/shell/t124.in
+++ b/use-gui/src/it/resources/testfiles/shell/t124.in
@@ -1,0 +1,6 @@
+!create a:A
+?a.foo()
+*[Warning] 1 postcondition in operation call `A::foo(self:a)' does not hold:
+*   postAlwaysInvalid: (result = 'Something else')
+* -> 'A static string' : String
+exit

--- a/use-gui/src/it/resources/testfiles/shell/t124.use
+++ b/use-gui/src/it/resources/testfiles/shell/t124.use
@@ -1,0 +1,8 @@
+model PostConditionFailure
+
+class A
+  operations
+    foo():String = 'A static string'
+      post postConditionValid: result = 'A static string'
+      post postAlwaysInvalid: result = 'Something else'
+end


### PR DESCRIPTION
- Set resultValue for operation call after evaluation of body expression
- The presence of this value is checked while evaluating post conditions

Closes #79 