### PR TITLE
Introduction of ExpInstanceOp and better error handling for constructors

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -7,7 +7,6 @@
         <option value="$PROJECT_DIR$/pom.xml" />
       </list>
     </option>
-    <option name="workspaceImportForciblyTurnedOn" value="true" />
   </component>
   <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />

--- a/use-core/src/main/java/org/tzi/use/analysis/coverage/AbstractCoverageVisitor.java
+++ b/use-core/src/main/java/org/tzi/use/analysis/coverage/AbstractCoverageVisitor.java
@@ -191,24 +191,7 @@ public abstract class AbstractCoverageVisitor implements ExpressionVisitor {
 	private Stack<MOperation> operationStack = new Stack<MOperation>();
 
 	@Override
-	public void visitObjOp(ExpObjOp exp) {
-		for (Expression ex : exp.getArguments()) {
-			ex.processWithVisitor(this);
-		}
-
-		addOperationCoverage((MClassifier) exp.getArguments()[0].type(),
-				exp.getOperation());
-
-		if (expandOperations && exp.getOperation().hasExpression()
-				&& !operationStack.contains(exp.getOperation())) {
-			operationStack.push(exp.getOperation());
-			exp.getOperation().expression().processWithVisitor(this);
-			operationStack.pop();
-		}
-	}
-
-	@Override
-	public void visitInstanceConstructor(ExpInstanceConstructor exp) {
+	public void visitInstanceOp(ExpInstanceOp exp) {
 		for (Expression ex : exp.getArguments()) {
 			ex.processWithVisitor(this);
 		}

--- a/use-core/src/main/java/org/tzi/use/parser/ocl/ASTOperationExpression.java
+++ b/use-core/src/main/java/org/tzi/use/parser/ocl/ASTOperationExpression.java
@@ -629,10 +629,10 @@ public class ASTOperationExpression extends ASTExpression {
         	}
         	
             try {
+                // constructor performs additional checks
                 if (op.isConstructor()) {
                     res = new ExpInstanceConstructor(op, fArgExprs);
                 } else {
-                    // constructor performs additional checks
                     res = new ExpObjOp(op, fArgExprs);
                 }
                 res.setSourcePosition(new SrcPos(fOp));

--- a/use-core/src/main/java/org/tzi/use/parser/ocl/ASTOperationExpression.java
+++ b/use-core/src/main/java/org/tzi/use/parser/ocl/ASTOperationExpression.java
@@ -630,7 +630,7 @@ public class ASTOperationExpression extends ASTExpression {
         	
             try {
                 if (op.isConstructor()) {
-                    res = new ExpInstanceConstructor(srcClassifier, fArgExprs);
+                    res = new ExpInstanceConstructor(op, fArgExprs);
                 } else {
                     // constructor performs additional checks
                     res = new ExpObjOp(op, fArgExprs);

--- a/use-core/src/main/java/org/tzi/use/parser/use/ASTOperation.java
+++ b/use-core/src/main/java/org/tzi/use/parser/use/ASTOperation.java
@@ -109,10 +109,6 @@ public class ASTOperation extends ASTAnnotatable {
         	}
         } else {
             resultType = fType.gen(ctx);
-            if (fIsConstructor && resultType != null) {
-                throw new SemanticException(fName, "Constructor " + StringUtil.inQuotes(fName.getText()) +
-                        " must not have result type.");
-            }
         }
 
         fOperation = ctx.modelFactory().createOperation(fName.getText(), varDeclList, resultType, fIsConstructor);
@@ -141,6 +137,11 @@ public class ASTOperation extends ASTAnnotatable {
         if (fOperation == null)
             return;
         
+        if (fIsConstructor && fOperation.resultType() != fOperation.cls()) {
+            throw new SemanticException(fName, "Constructor " + StringUtil.inQuotes(fName.getText()) +
+                    " must not have result type.");
+        }
+
         // enter parameters into scope of expression
         Symtable vars = ctx.varTable();
         vars.enterScope();
@@ -195,7 +196,7 @@ public class ASTOperation extends ASTAnnotatable {
 	/**
 	 * During compilation, this operation marks this AST-node
 	 * as invalid, because the signature had errors.
-	 * Any call to {@link #genFinal(Context)} afterwards
+	 * Any call to {@link #genFinal(Context)} afterward
 	 * is ignored.
 	 */
 	public void setSignatureGenFailed() {

--- a/use-core/src/main/java/org/tzi/use/parser/use/ASTOperation.java
+++ b/use-core/src/main/java/org/tzi/use/parser/use/ASTOperation.java
@@ -138,7 +138,7 @@ public class ASTOperation extends ASTAnnotatable {
             return;
         
         if (fIsConstructor && fOperation.resultType() != fOperation.cls()) {
-            throw new SemanticException(fName, "Constructor " + StringUtil.inQuotes(fName.getText()) +
+            throw new SemanticException(fName, "Instance constructor " + StringUtil.inQuotes(fName.getText()) +
                     " must not have result type.");
         }
 
@@ -162,7 +162,7 @@ public class ASTOperation extends ASTAnnotatable {
         try {
             if (fExpr != null ) {
                 if (fIsConstructor) {
-                    throw new MInvalidModelException("Constructor " + StringUtil.inQuotes(fName.getText())
+                    throw new MInvalidModelException("Instance constructor " + StringUtil.inQuotes(fName.getText())
                             + " must not have body.");
                 }
                 Expression expr = fExpr.gen(ctx);

--- a/use-core/src/main/java/org/tzi/use/uml/mm/MDataTypeImpl.java
+++ b/use-core/src/main/java/org/tzi/use/uml/mm/MDataTypeImpl.java
@@ -179,7 +179,7 @@ public class MDataTypeImpl extends MClassifierImpl implements MDataType {
                     .map(MModelElementImpl::name).collect(Collectors.toList());
             List<String> paramNames = op.paramNames();
             if (!CollectionUtil.equalLists(allAttributes, paramNames, Comparator.comparing(String::toString))) {
-                throw new MInvalidModelException("Constructor `" + opname + "' is missing parent attribute(s).");
+                throw new MInvalidModelException("Instance constructor `" + opname + "' is missing parent attribute(s).");
             }
         }
 

--- a/use-core/src/main/java/org/tzi/use/uml/mm/MOperation.java
+++ b/use-core/src/main/java/org/tzi/use/uml/mm/MOperation.java
@@ -202,8 +202,6 @@ public final class MOperation extends MModelElementImpl implements UseFileLocata
         // If no result type is set, use type of the expression
     	if (fResultType == null) {
     		fResultType = expr.type();
-    	//} else if (expr.isConstructorCall() == null) {
-            // TODO
     	} else if (expr.type() == null) {
     		throw new MInvalidModelException("The operation " + StringUtil.inQuotes(this.cls().name() + "." + this.name()) +
     				" does not have a declared result type and the result type of the defined expression could not be calculated. This" +

--- a/use-core/src/main/java/org/tzi/use/uml/ocl/expr/EvalNode.java
+++ b/use-core/src/main/java/org/tzi/use/uml/ocl/expr/EvalNode.java
@@ -48,7 +48,7 @@ public class EvalNode {
     
     /**
      * If <code>true</code>, the occurrence
-     * of variables in the text is replaces by the current value
+     * of variables in the text is replaced by the current value
      * of the variable.
      */
     private boolean fSubstituteVariables = false;
@@ -525,9 +525,9 @@ public class EvalNode {
 		}
 
 		@Override
-		public void visitObjOp(ExpObjOp exp) {
+		public void visitInstanceOp(ExpInstanceOp exp) {
 			if (replace(exp)) return;
-			super.visitObjOp(exp);
+			super.visitInstanceOp(exp);
 		}
 
 		@Override

--- a/use-core/src/main/java/org/tzi/use/uml/ocl/expr/ExpInstanceConstructor.java
+++ b/use-core/src/main/java/org/tzi/use/uml/ocl/expr/ExpInstanceConstructor.java
@@ -25,7 +25,6 @@ import org.tzi.use.uml.ocl.value.VarBindings;
 import org.tzi.use.uml.sys.*;
 import org.tzi.use.uml.ocl.value.Value;
 import org.tzi.use.uml.sys.ppcHandling.ExpressionPPCHandler;
-import org.tzi.use.util.Log;
 import org.tzi.use.util.StringUtil;
 
 import java.util.HashMap;

--- a/use-core/src/main/java/org/tzi/use/uml/ocl/expr/ExpInstanceConstructor.java
+++ b/use-core/src/main/java/org/tzi/use/uml/ocl/expr/ExpInstanceConstructor.java
@@ -25,6 +25,7 @@ import org.tzi.use.uml.ocl.value.VarBindings;
 import org.tzi.use.uml.sys.*;
 import org.tzi.use.uml.ocl.value.Value;
 import org.tzi.use.uml.sys.ppcHandling.ExpressionPPCHandler;
+import org.tzi.use.util.Log;
 import org.tzi.use.util.StringUtil;
 
 import java.util.HashMap;
@@ -39,7 +40,7 @@ import java.util.TreeMap;
  */
 public final class ExpInstanceConstructor extends ExpInstanceOp {
 
-    public ExpInstanceConstructor(MOperation constructor, Expression[] args) {
+    public ExpInstanceConstructor(MOperation constructor, Expression[] args) throws ExpInvalidException {
         super(constructor, args);
     }
 

--- a/use-core/src/main/java/org/tzi/use/uml/ocl/expr/ExpInstanceConstructor.java
+++ b/use-core/src/main/java/org/tzi/use/uml/ocl/expr/ExpInstanceConstructor.java
@@ -42,6 +42,26 @@ public final class ExpInstanceConstructor extends ExpInstanceOp {
 
     public ExpInstanceConstructor(MOperation constructor, Expression[] args) throws ExpInvalidException {
         super(constructor, args);
+
+        if (!(args[0].type().isTypeOfClass() || args[0].type().isTypeOfDataType()))
+            throw new ExpInvalidException(
+                    "Target expression of constructor must have " +
+                            "object type, found `" + args[0].type() + "'.");
+
+        // check for matching arguments
+        VarDeclList params = fOp.paramList();
+        if (params.size() != (args.length - 1) )
+            throw new ExpInvalidException(
+                    "Number of arguments does not match declaration of constructor `" +
+                            fOp.name() + "'. Expected " + params.size() + " argument(s), found " +
+                            (args.length - 1) + ".");
+
+        for (int i = 1; i < args.length; i++)
+            if (! args[i].type().conformsTo(params.varDecl(i - 1).type()) )
+                throw new ExpInvalidException(
+                        "Type mismatch in argument `" + params.varDecl(i - 1).name() +
+                                "'. Expected type `" + params.varDecl(i - 1).type() +
+                                "', found `" + args[i].type() + "'.");
     }
 
     @Override

--- a/use-core/src/main/java/org/tzi/use/uml/ocl/expr/ExpInstanceConstructor.java
+++ b/use-core/src/main/java/org/tzi/use/uml/ocl/expr/ExpInstanceConstructor.java
@@ -19,7 +19,6 @@
 
 package org.tzi.use.uml.ocl.expr;
 
-import org.tzi.use.uml.mm.MClassifier;
 import org.tzi.use.uml.mm.MOperation;
 import org.tzi.use.uml.ocl.value.DataTypeValueValue;
 import org.tzi.use.uml.ocl.value.VarBindings;
@@ -38,22 +37,10 @@ import java.util.TreeMap;
  *
  * @author Stefan Schoon
  */
-public final class ExpInstanceConstructor extends Expression {
+public final class ExpInstanceConstructor extends ExpInstanceOp {
 
-    private final MClassifier classifier;
-
-    private final MOperation constructor;
-
-    /**
-     * The arguments.
-     */
-    private final Expression[] fArgs;
-
-    public ExpInstanceConstructor(MClassifier classifier, Expression[] args) throws ExpInvalidException {
-        super(classifier);
-        this.classifier = classifier;
-        this.constructor = classifier.operation(classifier.name(), false);
-        fArgs = args;
+    public ExpInstanceConstructor(MOperation constructor, Expression[] args) {
+        super(constructor, args);
     }
 
     @Override
@@ -64,7 +51,7 @@ public final class ExpInstanceConstructor extends Expression {
 
         ctx.enter(this);
 
-        List<String> parameterNames = constructor.paramNames();
+        List<String> parameterNames = fOp.paramNames();
         int argsSize = parameterNames.size();
         Value[] arguments = new Value[argsSize];
         Map<String, Value> argValues = new TreeMap<>();
@@ -78,10 +65,10 @@ public final class ExpInstanceConstructor extends Expression {
         for (VarBindings.Entry e : ctx.varBindings()) {
             varBindings.put(e.getVarName(), e.getValue());
         }
-        MInstance self = new MDataTypeValue(classifier, classifier.name(), varBindings);
-        Value result = new DataTypeValueValue(classifier, self, argValues);
+        MInstance self = new MDataTypeValue(fClassifier, fClassifier.name(), varBindings);
+        Value result = new DataTypeValueValue(fClassifier, self, argValues);
 
-        MOperationCall operationCall = new MOperationCall(this, self, constructor, arguments);
+        MOperationCall operationCall = new MOperationCall(this, self, fOp, arguments);
         operationCall.setPreferredPPCHandler(ExpressionPPCHandler.getDefaultOutputHandler());
         operationCall.setResultValue(result);
 
@@ -106,40 +93,9 @@ public final class ExpInstanceConstructor extends Expression {
     }
 
     @Override
-    protected boolean childExpressionRequiresPreState() {
-        for (Expression e : fArgs) {
-            if (e.requiresPreState()) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    @Override
     public StringBuilder toString(StringBuilder sb) {
-        sb.append(classifier.name()).append("(");
+        sb.append(fClassifier.name()).append("(");
         StringUtil.fmtSeqBuffered(sb, fArgs, 1, ", ");
         return sb.append(")");
-    }
-
-    @Override
-    public String name() {
-        return constructor.name();
-    }
-
-    /**
-     * All arguments of the expression.
-     */
-    public Expression[] getArguments() {
-        return fArgs;
-    }
-
-    public MOperation getOperation() {
-        return constructor;
-    }
-
-    @Override
-    public void processWithVisitor(ExpressionVisitor visitor) {
-        visitor.visitInstanceConstructor(this);
     }
 }

--- a/use-core/src/main/java/org/tzi/use/uml/ocl/expr/ExpInstanceConstructor.java
+++ b/use-core/src/main/java/org/tzi/use/uml/ocl/expr/ExpInstanceConstructor.java
@@ -45,14 +45,14 @@ public final class ExpInstanceConstructor extends ExpInstanceOp {
 
         if (!(args[0].type().isTypeOfClass() || args[0].type().isTypeOfDataType()))
             throw new ExpInvalidException(
-                    "Target expression of constructor must have " +
+                    "Target expression of instance constructor must have " +
                             "object type, found `" + args[0].type() + "'.");
 
         // check for matching arguments
         VarDeclList params = fOp.paramList();
         if (params.size() != (args.length - 1) )
             throw new ExpInvalidException(
-                    "Number of arguments does not match declaration of constructor `" +
+                    "Number of arguments does not match declaration of instance constructor `" +
                             fOp.name() + "'. Expected " + params.size() + " argument(s), found " +
                             (args.length - 1) + ".");
 

--- a/use-core/src/main/java/org/tzi/use/uml/ocl/expr/ExpInstanceOp.java
+++ b/use-core/src/main/java/org/tzi/use/uml/ocl/expr/ExpInstanceOp.java
@@ -19,31 +19,11 @@ public abstract class ExpInstanceOp extends Expression {
 
     protected final MClassifier fClassifier;
 
-    public ExpInstanceOp(MOperation op, Expression[] args) throws ExpInvalidException {
+    public ExpInstanceOp(MOperation op, Expression[] args) {
         super(op.resultType());
         fOp = op;
         fArgs = args;
         fClassifier = op.cls();
-
-        if (!(args[0].type().isTypeOfClass() || args[0].type().isTypeOfDataType()))
-            throw new ExpInvalidException(
-                    "Target expression of object operation must have " +
-                            "object type, found `" + args[0].type() + "'.");
-
-        // check for matching arguments
-        VarDeclList params = fOp.paramList();
-        if (params.size() != (args.length - 1) )
-            throw new ExpInvalidException(
-                    "Number of arguments does not match declaration of operation `" +
-                            fOp.name() + "'. Expected " + params.size() + " argument(s), found " +
-                            (args.length - 1) + ".");
-
-        for (int i = 1; i < args.length; i++)
-            if (! args[i].type().conformsTo(params.varDecl(i - 1).type()) )
-                throw new ExpInvalidException(
-                        "Type mismatch in argument `" + params.varDecl(i - 1).name() +
-                                "'. Expected type `" + params.varDecl(i - 1).type() +
-                                "', found `" + args[i].type() + "'.");
     }
 
     public abstract Value eval(EvalContext ctx);

--- a/use-core/src/main/java/org/tzi/use/uml/ocl/expr/ExpInstanceOp.java
+++ b/use-core/src/main/java/org/tzi/use/uml/ocl/expr/ExpInstanceOp.java
@@ -1,0 +1,62 @@
+package org.tzi.use.uml.ocl.expr;
+
+import org.tzi.use.uml.mm.MClassifier;
+import org.tzi.use.uml.mm.MOperation;
+import org.tzi.use.uml.ocl.value.Value;
+
+/**
+ * Abstract class for operations and constructors defined by a classifier.
+ *
+ * @author Stefan Schoon
+ */
+public abstract class ExpInstanceOp extends Expression {
+    protected final MOperation fOp;
+
+    /**
+     * The arguments, first one is "receiver" object
+     */
+    protected final Expression[] fArgs;
+
+    protected final MClassifier fClassifier;
+
+    public ExpInstanceOp(MOperation op, Expression[] args) {
+        super(op.resultType());
+        fOp = op;
+        fArgs = args;
+        fClassifier = op.cls();
+    }
+
+    public abstract Value eval(EvalContext ctx);
+
+    public MOperation getOperation() {
+        return fOp;
+    }
+
+    /**
+     * All arguments of the expression.
+     * Index 0 is the receiver object (self)
+     */
+    public Expression[] getArguments() {
+        return fArgs;
+    }
+
+    @Override
+    public void processWithVisitor(ExpressionVisitor visitor) {
+        visitor.visitInstanceOp(this);
+    }
+
+    @Override
+    protected boolean childExpressionRequiresPreState() {
+        for (Expression e : fArgs) {
+            if (e.requiresPreState()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public String name() {
+        return fOp.name();
+    }
+}

--- a/use-core/src/main/java/org/tzi/use/uml/ocl/expr/ExpInstanceOp.java
+++ b/use-core/src/main/java/org/tzi/use/uml/ocl/expr/ExpInstanceOp.java
@@ -19,11 +19,31 @@ public abstract class ExpInstanceOp extends Expression {
 
     protected final MClassifier fClassifier;
 
-    public ExpInstanceOp(MOperation op, Expression[] args) {
+    public ExpInstanceOp(MOperation op, Expression[] args) throws ExpInvalidException {
         super(op.resultType());
         fOp = op;
         fArgs = args;
         fClassifier = op.cls();
+
+        if (!(args[0].type().isTypeOfClass() || args[0].type().isTypeOfDataType()))
+            throw new ExpInvalidException(
+                    "Target expression of object operation must have " +
+                            "object type, found `" + args[0].type() + "'.");
+
+        // check for matching arguments
+        VarDeclList params = fOp.paramList();
+        if (params.size() != (args.length - 1) )
+            throw new ExpInvalidException(
+                    "Number of arguments does not match declaration of operation `" +
+                            fOp.name() + "'. Expected " + params.size() + " argument(s), found " +
+                            (args.length - 1) + ".");
+
+        for (int i = 1; i < args.length; i++)
+            if (! args[i].type().conformsTo(params.varDecl(i - 1).type()) )
+                throw new ExpInvalidException(
+                        "Type mismatch in argument `" + params.varDecl(i - 1).name() +
+                                "'. Expected type `" + params.varDecl(i - 1).type() +
+                                "', found `" + args[i].type() + "'.");
     }
 
     public abstract Value eval(EvalContext ctx);

--- a/use-core/src/main/java/org/tzi/use/uml/ocl/expr/ExpObjOp.java
+++ b/use-core/src/main/java/org/tzi/use/uml/ocl/expr/ExpObjOp.java
@@ -32,20 +32,13 @@ import java.util.List;
  *
  * @author  Mark Richters
  */
-public final class ExpObjOp extends Expression {
-    private MOperation fOp;
-    
-    /**
-     * The arguments, first one is "receiver" object
-     */
-    private Expression[] fArgs;
-    
+public final class ExpObjOp extends ExpInstanceOp {
+
     public ExpObjOp(MOperation op, Expression[] args) 
         throws ExpInvalidException
     {
-        super(op.resultType());
-        fOp = op;
-        fArgs = args;
+        super(op, args);
+
         if (!(args[0].type().isTypeOfClass() || args[0].type().isTypeOfDataType()))
             throw new ExpInvalidException(
                                           "Target expression of object operation must have " +
@@ -158,33 +151,4 @@ public final class ExpObjOp extends Expression {
         
         return sb.append(")");
     }
-    
-    public MOperation getOperation() {
-        return fOp;
-    }
-
-    /**
-     * All arguments of the expression.
-     * Index 0 is the receiver object (self)
-     * @return
-     */
-    public Expression[] getArguments() {
-        return fArgs;
-    }
-
-	@Override
-	public void processWithVisitor(ExpressionVisitor visitor) {
-		visitor.visitObjOp(this);
-	}
-
-	@Override
-	protected boolean childExpressionRequiresPreState() {
-		for (Expression e : fArgs) {
-			if (e.requiresPreState()) {
-				return true;
-			}
-		}
-		
-		return false;
-	}
 }

--- a/use-core/src/main/java/org/tzi/use/uml/ocl/expr/ExpressionPrintVisitor.java
+++ b/use-core/src/main/java/org/tzi/use/uml/ocl/expr/ExpressionPrintVisitor.java
@@ -337,7 +337,7 @@ public class ExpressionPrintVisitor implements ExpressionVisitor {
 	}
 
 	@Override
-	public void visitObjOp(ExpObjOp exp) {
+	public void visitInstanceOp(ExpInstanceOp exp) {
 		exp.getArguments()[0].processWithVisitor(this);
 		writer.write('.');
 		writer.write(operation(exp.getOperation().name(), exp));
@@ -349,24 +349,6 @@ public class ExpressionPrintVisitor implements ExpressionVisitor {
 				writer.write(ws());
 			}
 			
-			exp.getArguments()[i].processWithVisitor(this);
-		}
-		writer.write(operator(")", exp));
-	}
-
-	@Override
-	public void visitInstanceConstructor(ExpInstanceConstructor exp) {
-		exp.getArguments()[0].processWithVisitor(this);
-		writer.write('.');
-		writer.write(operation(exp.getOperation().name(), exp));
-		atPre(exp);
-		writer.write(operator("(", exp));
-		for (int i = 1; i < exp.getArguments().length; ++i) {
-			if (i > 1) {
-				writer.write(",");
-				writer.write(ws());
-			}
-
 			exp.getArguments()[i].processWithVisitor(this);
 		}
 		writer.write(operator(")", exp));

--- a/use-core/src/main/java/org/tzi/use/uml/ocl/expr/ExpressionVisitor.java
+++ b/use-core/src/main/java/org/tzi/use/uml/ocl/expr/ExpressionVisitor.java
@@ -48,8 +48,7 @@ public interface ExpressionVisitor {
 	void visitLet (ExpLet exp);
 	void visitNavigation (ExpNavigation exp);
 	void visitObjAsSet (ExpObjAsSet exp);
-	void visitObjOp (ExpObjOp exp);
-	void visitInstanceConstructor(ExpInstanceConstructor exp);
+	void visitInstanceOp(ExpInstanceOp exp);
 	void visitObjRef (ExpObjRef exp);
 	void visitOne (ExpOne exp);
 	void visitOrderedSetLiteral (ExpOrderedSetLiteral exp);

--- a/use-core/src/main/resources/grammars/base/USEBase.gpart
+++ b/use-core/src/main/resources/grammars/base/USEBase.gpart
@@ -251,6 +251,9 @@ operationDefinition[ASTClassifier c] returns [ASTOperation n]
     ( COLON t = type )? 
     {
       ASTType type = $t.n;
+      if (type == null && isConstructor) {
+        type = new ASTSimpleType($c.getName());
+      }
       $n = new ASTOperation($name, $pl.paramList, type, isConstructor);
       $n.setAnnotations($as.annotations);
     }

--- a/use-core/src/test/resources/org/tzi/use/parser/t25.fail
+++ b/use-core/src/test/resources/org/tzi/use/parser/t25.fail
@@ -1,1 +1,2 @@
-t25.use:8:6: Definition of constructor `C' only possible in data types.
+t25.use:9:6: Definition of constructor `C' only possible in data types.
+t25.use:5:2: Instance constructor `D' must not have body.

--- a/use-core/src/test/resources/org/tzi/use/parser/t25.use
+++ b/use-core/src/test/resources/org/tzi/use/parser/t25.use
@@ -2,7 +2,8 @@ model t25
 
 dataType D
 operations
-  D(a : Integer, b : Integer)
+  D(a : Integer, b : Integer) =
+    D(a, b)
 end
 
 class C

--- a/use-core/src/test/resources/org/tzi/use/parser/t26.fail
+++ b/use-core/src/test/resources/org/tzi/use/parser/t26.fail
@@ -1,6 +1,6 @@
 t26.use:3:9: Data type `C' already contains an attribute named `c0'.
 t26.use:3:9: Data type `C' already contains an operation named `C'.
 t26.use:9:9: Attribute with name `c0' already defined in a super data type.
-t26.use:14:9: Constructor `E' is missing parent attribute(s).
-t26.use:19:9: Constructor `F' is missing parent attribute(s).
-t26.use:36:2: Constructor `I' must not have result type.
+t26.use:14:9: Instance constructor `E' is missing parent attribute(s).
+t26.use:19:9: Instance constructor `F' is missing parent attribute(s).
+t26.use:36:2: Instance constructor `I' must not have result type.

--- a/use-core/src/test/resources/org/tzi/use/parser/t26.fail
+++ b/use-core/src/test/resources/org/tzi/use/parser/t26.fail
@@ -3,5 +3,4 @@ t26.use:3:9: Data type `C' already contains an operation named `C'.
 t26.use:9:9: Attribute with name `c0' already defined in a super data type.
 t26.use:14:9: Constructor `E' is missing parent attribute(s).
 t26.use:19:9: Constructor `F' is missing parent attribute(s).
-t26.use:31:2: Constructor `H' must not have result type.
 t26.use:36:2: Constructor `I' must not have result type.

--- a/use-core/src/test/resources/org/tzi/use/parser/t27.fail
+++ b/use-core/src/test/resources/org/tzi/use/parser/t27.fail
@@ -1,1 +1,1 @@
-t27.use:8:9: Constructor `B' is missing parent attribute(s).
+t27.use:8:9: Instance constructor `B' is missing parent attribute(s).


### PR DESCRIPTION
Suggestion to introduce a new abstract parent class ExpInstanceOp, which outsources the common features of ExpObjOp and ExpInstanceConstructor.

Parameter checks are now performed not only for object operations, but also for constructors.

The USE.g grammar has been changed so that constructors have the type of their classifier as their result type by default. This simplifies the handling of constructors for the above change.
