### PR TITLE
Fix NullPointerException in diagram layout methods

### DIFF
--- a/use-gui/src/main/java/org/tzi/use/gui/views/diagrams/DiagramView.java
+++ b/use-gui/src/main/java/org/tzi/use/gui/views/diagrams/DiagramView.java
@@ -882,7 +882,7 @@ public abstract class DiagramView extends JPanel
 
     //Manage Diffrent Type Of Layouts
     protected synchronized void HierarchicalLayout(int HorizontalSpacing, int VerticalSpacing, boolean IsPutAssociationsOnRelationsEnabled) {
-        if (fLayouter == null) {
+        if (fAllLayoutTypes == null) {
             int w = getWidth();
             int h = getHeight();
             if (w == 0 || h == 0)
@@ -899,7 +899,7 @@ public abstract class DiagramView extends JPanel
     }
 
     protected synchronized void HierarchicalUpsideDownLayout(int HorizontalSpacing, int VerticalSpacing, boolean IsPutAssociationsOnRelationsEnabled) {
-        if (fLayouter == null) {
+        if (fAllLayoutTypes == null) {
             int w = getWidth();
             int h = getHeight();
             if (w == 0 || h == 0)
@@ -915,7 +915,7 @@ public abstract class DiagramView extends JPanel
     }
 
     protected synchronized void HorizontalLayout(int HorizontalSpacing, int VerticalSpacing, boolean IsPutAssociationsOnRelationsEnabled) {
-        if (fLayouter == null) {
+        if (fAllLayoutTypes == null) {
             int w = getWidth();
             int h = getHeight();
             if (w == 0 || h == 0)
@@ -931,7 +931,7 @@ public abstract class DiagramView extends JPanel
     }
 
     protected synchronized void HorizontalRightToLeftLayout(int HorizontalSpacing, int VerticalSpacing, boolean IsPutAssociationsOnRelationsEnabled) {
-        if (fLayouter == null) {
+        if (fAllLayoutTypes == null) {
             int w = getWidth();
             int h = getHeight();
             if (w == 0 || h == 0)
@@ -947,7 +947,7 @@ public abstract class DiagramView extends JPanel
     }
 
     protected synchronized void LandscapeSwimlaneLayout(int HorizontalSpacing, int VerticalSpacing, boolean IsPutAssociationsOnRelationsEnabled) {
-        if (fLayouter == null) {
+        if (fAllLayoutTypes == null) {
             int w = getWidth();
             int h = getHeight();
             if (w == 0 || h == 0)
@@ -963,7 +963,7 @@ public abstract class DiagramView extends JPanel
     }
 
     protected synchronized void PortraitSwimlaneLayout(int HorizontalSpacing, int VerticalSpacing, boolean IsPutAssociationsOnRelationsEnabled) {
-        if (fLayouter == null) {
+        if (fAllLayoutTypes == null) {
             int w = getWidth();
             int h = getHeight();
             if (w == 0 || h == 0)


### PR DESCRIPTION
- Fixed incorrect null check in 6 layout methods
- Changed 'if (fLayouter == null)' to 'if (fAllLayoutTypes == null)'
- Methods affected: HierarchicalLayout, HierarchicalUpsideDownLayout, HorizontalLayout, HorizontalRightToLeftLayout, LandscapeSwimlaneLayout, PortraitSwimlaneLayout
- Resolves runtime error when calling layout methods on uninitialized diagrams

Fixes: Diagram layout NullPointerException when fAllLayoutTypes is null