### PR TITLE
Change master to main branch

### DIFF
--- a/.github/workflows/metrics-collection.yml
+++ b/.github/workflows/metrics-collection.yml
@@ -4,7 +4,7 @@ on:
     workflows: ["Java CI with Maven"]
     types:
       - completed
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   collect-metrics:

--- a/docs/history.html
+++ b/docs/history.html
@@ -29,7 +29,7 @@
         <h2>Historical Metrics Overview</h2>
         <p>his page provides detailed insights into the historical development of software quality metrics for USE.
             The diagrams below depict the evolution of metrics over the last 15 years, dating back to 2010.
-            All metrics were collected only for the master branch commits. Two different build systems were identified -
+            All metrics were collected only for the main branch commits. Two different build systems were identified -
             Ant and Maven - and metrics collection is additionally divided by those categories.
             </p>
     </section>

--- a/docs/index.html
+++ b/docs/index.html
@@ -31,7 +31,7 @@
     <h2>Dashboard Overview</h2>
     <p>This dashboard provides detailed insights into the software quality metrics of the USE project.
       The diagrams below highlight key aspects of the structure of the codebase and its evolution over time.
-      The metrics represent the master branch only, no other branches are taken into consideration.
+      The metrics represent the main branch only, no other branches are taken into consideration.
       The goal of this dashboard is to encourage developers to pay attention to how their changes impact architecture
       and to eventually guide them to adopt an evolutionary architecture approach according to <a href="https://evolutionaryarchitecture.com/index.html" target="_blank">Neal Ford et.al.</a></p>
   </section>

--- a/docs/scripts/Maven/maven_buildtime_test.ps1
+++ b/docs/scripts/Maven/maven_buildtime_test.ps1
@@ -97,7 +97,7 @@ function Process-Commit {
 Initialize-Results-File -FilePath $RESULTS_DIR -Header "date,time,commit,buildtime"
 
 Setup-Repo -TempDir $TEMP_DIR -OriginalUseDir $ORIGINAL_USE_DIR
-git checkout -q master
+git checkout -q main
 
 #########################################
 # Main Loop starts here #

--- a/docs/scripts/general_utilities.ps1
+++ b/docs/scripts/general_utilities.ps1
@@ -166,11 +166,11 @@ function Store-ArchTest {
     param(
         $TestFilePath
     )
-    # In case we're not on master already
-    git checkout -q master
+    # In case we're not on main already
+    git checkout -q main
 
     if (-not (Test-Path $TestFilePath)) {
-        Log-Message "Required file $TestFilePath not found in master branch. Exiting."
+        Log-Message "Required file $TestFilePath not found in main branch. Exiting."
         exit 1
     }
 


### PR DESCRIPTION
## Summary
Align the documentation, helper scripts and the metrics collection workflow with a main default branch instead of master. This PR updates all branch name references that are relevant for metrics collection and the associated docs so the repository can consistently use main going forward.

## Motivation
The project historically used master as the default branch name, which is still referenced in scripts and documentation for metrics collection. To prepare a clean migration to main as the default branch and avoid confusion between branch names, all user-facing and automation-facing references should point to main. This PR keeps behavior equivalent but ensures that future builds and metrics collection run against the main branch.

## What changed

- Updated PowerShell scripts used for metrics collection to check out main instead of master.
-  Adjusted GitHub Actions workflow filters so the metrics workflow listens to main branch runs.
- Updated documentation texts to state that metrics are collected from the main branch commits.
- Aligned log and error messages to mention main instead of master.

### Files included in this PR
- .github/workflows/metrics-collection.yml – change branches: [ master ] to branches: [ main ].
-  docs/scripts/Maven/maven_buildtime_test.ps1 – use git checkout -q main when preparing the repo.
- docs/scripts/general_utilities.ps1 – switch default checkout and log messages from master to main.
- docs/history.html – update description to “metrics collected for the main branch commits”.
- docs/index.html – update dashboard description to “The metrics represent the main branch only”.

## Behavior & backward compatibility
Runtime behavior is intended to stay the same, with the only semantic change being the branch name: all scripts and the metrics workflow still operate on the default branch, now called main. Until the repository’s default branch is actually switched on GitHub, the updated scripts and workflow should only be used once main exists and is kept in sync with the previous default. No business logic or metric definitions were changed in this PR.

## Testing / QA instructions

### Scripts (PowerShell):

- [x] Ensure that the repository has a main branch containing the current default branch state.
- [x] Run the metrics build script locally, e.g.:
```
    powershell
    cd path\to\use
    docs\scripts\Maven\maven_buildtime_test.ps1
```
- [x] Verify that the script checks out main without errors and produces the expected results files.

### GitHub Actions:

    Once main exists and is set as the default branch on GitHub, push a test commit to main.
    Confirm that the metrics-collection workflow is triggered for the main branch and completes successfully.

### Acceptance checklist for merge

- [x] main branch exists and contains the current default code state.
- [x] Metrics scripts run successfully against main without checkout errors.
- [ ] metrics-collection workflow triggers on main and completes successfully.
- [ ] Documentation consistently refers to main as the metrics source branch.


## Important Steps
- [ ] On GitHub, set main as the default branch for the repository once the branch is available and up to date.

## Next steps (recommended)
- [ ] Optionally remove or archive the old master branch after consumers have migrated to main.
- [ ] Update any external documentation, dashboards or CI jobs outside this repository that still reference master.

## Risks & mitigation

- Risk: Scripts or workflows are executed before a main branch exists, causing checkout failures.
- Mitigation: Only use the updated scripts and workflow after main has been created and synchronized with the current default branch.
- Risk: External tools still rely on the master branch name.
- [ ] Mitigation: Communicate the planned switch to main and update external configuration as part of the migration.

## Suggested reviewers & labels
- Reviewers: maintainers responsible for metrics collection, documentation and CI.
- Labels: maintenance, ci, documentation, branch-migration.