### PR TITLE
fix: replace gsbase with guava-testlib for equals tests

### DIFF
--- a/use-core/pom.xml
+++ b/use-core/pom.xml
@@ -66,12 +66,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>gsbase</groupId>
-            <artifactId>gsbase</artifactId>
-            <version>2.0.1</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.tngtech.archunit</groupId>
             <artifactId>archunit-junit5</artifactId>
             <version>1.3.0</version>

--- a/use-core/src/test/java/org/tzi/use/uml/ocl/type/TypeTest.java
+++ b/use-core/src/test/java/org/tzi/use/uml/ocl/type/TypeTest.java
@@ -35,7 +35,7 @@ import org.tzi.use.uml.mm.MClass;
 import org.tzi.use.uml.mm.MDataType;
 import org.tzi.use.uml.ocl.type.Type.VoidHandling;
 
-import com.gargoylesoftware.base.testing.EqualsTester;
+import com.google.common.testing.EqualsTester;
 
 /**
  * Test Type classes.
@@ -233,47 +233,69 @@ public class TypeTest extends TestCase {
         // boolean 
         BooleanType bt1 = new BooleanType();
         BooleanType bt2 = new BooleanType();
-        new EqualsTester(bt1, bt2, null, null);
+        new EqualsTester()
+                .addEqualityGroup(bt1, bt2)
+                .testEquals();
         assertEquals( bt1.hashCode(), bt2.hashCode() );
-        
-        
+
+
         // integer
         IntegerType it1 = new IntegerType();
         IntegerType it2 = new IntegerType();
-        new EqualsTester(it1, it2, null, null);
+        new EqualsTester()
+                .addEqualityGroup(it1, it2)
+                .testEquals();
         assertEquals( it1.hashCode(), it2.hashCode() );
 
         // real
         RealType rt1 = new RealType();
         RealType rt2 = new RealType();
-        new EqualsTester(rt1, rt2, null, null);
+        new EqualsTester()
+                .addEqualityGroup(rt1, rt2)
+                .testEquals();
         assertEquals( rt1.hashCode(), rt2.hashCode() );
-        
-        
+
+
         SetType sett1 = new SetType(bt1);
         SetType sett2 = new SetType(bt1);
         SetType sett3 = new SetType(it1);
-        new EqualsTester(sett1, sett2, sett3, null);
-        
+        new EqualsTester()
+                .addEqualityGroup(sett1, sett2)
+                .addEqualityGroup(sett3)
+                .testEquals();
+
         BagType bagt1 = new BagType(bt1);
         BagType bagt2 = new BagType(bt1);
         BagType bagt3 = new BagType(it1);
-        new EqualsTester(bagt1, bagt2, bagt3, null);
+        new EqualsTester()
+                .addEqualityGroup(bagt1, bagt2)
+                .addEqualityGroup(bagt3)
+                .testEquals();
 
         SequenceType sequencet1 = new SequenceType(bt1);
         SequenceType sequencet2 = new SequenceType(bt1);
         SequenceType sequencet3 = new SequenceType(it1);
-        new EqualsTester(sequencet1, sequencet2, sequencet3, null);
-        
+        new EqualsTester()
+                .addEqualityGroup(sequencet1, sequencet2)
+                .addEqualityGroup(sequencet3)
+                .testEquals();
+
         CollectionType collectiont1 = new CollectionType(bt1);
         CollectionType collectiont2 = new CollectionType(bt1);
         CollectionType collectiont3 = new CollectionType(it1);
-        new EqualsTester(collectiont1, collectiont2, collectiont3, sett1);
+        new EqualsTester()
+                .addEqualityGroup(collectiont1, collectiont2)
+                .addEqualityGroup(collectiont3)
+                .addEqualityGroup(sett1)
+                .testEquals();
 
         EnumType enumt1 = new EnumType(null, "e1", new LinkedList<String>() );
         EnumType enumt2 = new EnumType(null, "e1", new LinkedList<String>() );
         EnumType enumt3 = new EnumType(null, "e2", new LinkedList<String>() );
-        new EqualsTester(enumt1, enumt2, enumt3, null);
+        new EqualsTester()
+                .addEqualityGroup(enumt1, enumt2)
+                .addEqualityGroup(enumt3)
+                .testEquals();
 
         TupleType.Part part1 = new TupleType.Part(0, "p1", sett1);
         TupleType.Part part2 = new TupleType.Part(1, "p1", sett2);
@@ -281,7 +303,10 @@ public class TypeTest extends TestCase {
         TupleType tuplet1 = new TupleType( new TupleType.Part[]{part1});
         TupleType tuplet2 = new TupleType( new TupleType.Part[]{part2});
         TupleType tuplet3 = new TupleType( new TupleType.Part[]{part3});
-        new EqualsTester(tuplet1, tuplet2, tuplet3, null);
+        new EqualsTester()
+                .addEqualityGroup(tuplet1, tuplet2)
+                .addEqualityGroup(tuplet3)
+                .testEquals();
                 
     }
 

--- a/use-core/src/test/java/org/tzi/use/uml/ocl/value/ValueTest.java
+++ b/use-core/src/test/java/org/tzi/use/uml/ocl/value/ValueTest.java
@@ -19,7 +19,7 @@
 
 package org.tzi.use.uml.ocl.value;
 
-import com.gargoylesoftware.base.testing.EqualsTester;
+import com.google.common.testing.EqualsTester;
 import junit.framework.TestCase;
 import org.tzi.use.uml.ocl.type.EnumType;
 import org.tzi.use.uml.ocl.type.TypeFactory;
@@ -182,7 +182,11 @@ public class ValueTest extends TestCase {
         SetValue intSet4 = new SetValue(TypeFactory.mkInteger()) { /*subclass*/ };
         intSet4.add(IntegerValue.valueOf(1));
         
-        new EqualsTester(intSet1, intSet2, intSet3, intSet4);
+        new EqualsTester()
+                .addEqualityGroup(intSet1, intSet2)
+                .addEqualityGroup(intSet3)
+                .addEqualityGroup(intSet4)
+                .testEquals();
     }
     
     public void testSequenceEquals() {
@@ -195,7 +199,11 @@ public class ValueTest extends TestCase {
         SequenceValue intSequence4 = new SequenceValue(TypeFactory.mkInteger()) { /*subclass*/ };
         intSequence4.add(IntegerValue.valueOf(1));
         
-        new EqualsTester(intSequence1, intSequence2, intSequence3, intSequence4);
+        new EqualsTester()
+                .addEqualityGroup(intSequence1, intSequence2)
+                .addEqualityGroup(intSequence3)
+                .addEqualityGroup(intSequence4)
+                .testEquals();
     }
 
 
@@ -209,7 +217,11 @@ public class ValueTest extends TestCase {
         BagValue intBag4 = new BagValue(TypeFactory.mkInteger()) { /*subclass*/ };
         intBag4.add(IntegerValue.valueOf(1));
         
-        new EqualsTester(intBag1, intBag2, intBag3, intBag4);
+        new EqualsTester()
+                .addEqualityGroup(intBag1, intBag2)
+                .addEqualityGroup(intBag3)
+                .addEqualityGroup(intBag4)
+                .testEquals();
     }
     
     

--- a/use-gui/pom.xml
+++ b/use-gui/pom.xml
@@ -155,9 +155,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>gsbase</groupId>
-            <artifactId>gsbase</artifactId>
-            <version>2.0.1</version>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava-testlib</artifactId>
+            <version>33.5.0-jre</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/use-gui/src/test/java/org/tzi/use/gui/views/diagrams/util/DirectedLineTest.java
+++ b/use-gui/src/test/java/org/tzi/use/gui/views/diagrams/util/DirectedLineTest.java
@@ -19,7 +19,7 @@
 
 package org.tzi.use.gui.views.diagrams.util;
 
-import com.gargoylesoftware.base.testing.EqualsTester;
+import com.google.common.testing.EqualsTester;
 import junit.framework.TestCase;
 
 /**
@@ -40,6 +40,10 @@ public class DirectedLineTest extends TestCase {
             (DirectedLine)DirectedLineFactory.createSolidDirectedLine(40,30,20,10);
         DashedDirectedLine sameValuesFromSubClass = 
             (DashedDirectedLine)DirectedLineFactory.createDashedDirectedLine(10,20,30,40);
-        new EqualsTester(orig, equal, differentButSameClass, sameValuesFromSubClass);
+        new EqualsTester()
+                .addEqualityGroup(orig, equal)
+                .addEqualityGroup(differentButSameClass)
+                .addEqualityGroup(sameValuesFromSubClass)
+                .testEquals();
     }
 } 


### PR DESCRIPTION
Closes #4

## What

Replaces the `gsbase` dependency (last updated 2014) with `guava-testlib`, which is actively maintained, for testing correct `equals()`/`hashCode()` implementations.

## Changes

- **`use-core/pom.xml`** — remove `gsbase`, keep the existing `guava-testlib` entry (already declared)
- **`use-gui/pom.xml`** — replace `gsbase` with `guava-testlib`
- **3 test files** — migrate from gsbase's 4-arg constructor to guava's equality-group API

## API mapping

All affected `equals()` implementations use `getClass()` checks, so subclass instances form their own group:

```java
// before
new EqualsTester(original, equal, different, subclass);

// after
new EqualsTester()
    .addEqualityGroup(original, equal)
    .addEqualityGroup(different)
    .addEqualityGroup(subclass)
    .testEquals();
```

`null` arguments are omitted — guava handles null checks internally.

## Files changed

| File | Usages |
|------|--------|
| `use-core/.../ValueTest.java` | 3 (Set, Sequence, Bag values) |
| `use-core/.../TypeTest.java` | 8 (Boolean, Integer, Real, Set, Bag, Sequence, Collection, Enum, Tuple types) |
| `use-gui/.../DirectedLineTest.java` | 1 |

All tests pass (verified locally).