### PR TITLE
Configurable directories for plugins and OCL extensions (#20)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,9 @@ Please see the file `README' for a description of how to report bugs.
 
 ** Changes between version 7.1.0 and X.X.X
 * USE now supports data types
+* [USE] The plugin and OCL extension directories can now be configured at
+  startup with the -pluginDir and -extensionsDir arguments, instead of being
+  fixed to <home>/lib/plugins and <home>/oclextensions (#20)
 
 ** Changes between version 5.2.0 and 6.0.0
 * New OCL complexity plugin

--- a/use-core/src/main/java/org/tzi/use/config/Options.java
+++ b/use-core/src/main/java/org/tzi/use/config/Options.java
@@ -185,6 +185,11 @@ public class Options {
 	public static Path pluginDir = null;
 
 	/**
+	 * Directory containing the OCL extension definitions.
+	 */
+	public static Path oclExtensionsDir = null;
+
+	/**
      * Preferred size of the diagram views. 
      */
     public static Dimension fDiagramDimension = new Dimension( 600, 600 );
@@ -246,6 +251,12 @@ public class Options {
 		System.out.println("  -noplugins    do not use plugins");
         System.out.println("  -h            print help");
         System.out.println("  -H=path       home of use installation");
+		System.out.println("  -pluginDir=path");
+		System.out.println("                directory to load plugins from");
+		System.out.println("                (default: <home>/lib/plugins)");
+		System.out.println("  -extensionsDir=path");
+		System.out.println("                directory to load OCL extensions from");
+		System.out.println("                (default: <home>/oclextensions)");
 		System.out.println("  -nr           suppress warnings about missing readline library");
 		System.out.println("  -q            reads spec_file, executes cmd_file, and checks constraints");
 		System.out.println("                exit code is 1 if constraints fail, otherwise 0");
@@ -319,6 +330,7 @@ public class Options {
 		checkWarningsUnrelatedTypes = WarningType.WARN;
 		doPLUGIN = true;
 		pluginDir = null;
+		oclExtensionsDir = null;
 		fDiagramDimension = new Dimension( 600, 600 );
 		props = null;
 		specFilename = null;
@@ -349,14 +361,30 @@ public class Options {
                 	Options.doGUI = false;
                 } else if (arg.equals("noplugins")) {
 					Options.doPLUGIN = false;
-                } else if (arg.startsWith("H=")) { 
+                } else if (arg.startsWith("H=")) {
                 	try {
                 		homeDir = Paths.get(arg.substring(2));
                 	} catch (InvalidPathException e) {
                 		System.err.println("Invalid path " + StringUtil.inQuotes(arg.substring(2)) + " for home directory specified.");
                 		System.exit(1);
                 	}
-                } else if (arg.equals("nr")) { 
+                } else if (arg.startsWith("pluginDir=")) {
+                	String value = arg.substring("pluginDir=".length());
+                	try {
+                		pluginDir = Paths.get(value);
+                	} catch (InvalidPathException e) {
+                		System.err.println("Invalid path " + StringUtil.inQuotes(value) + " for plugin directory specified.");
+                		System.exit(1);
+                	}
+                } else if (arg.startsWith("extensionsDir=")) {
+                	String value = arg.substring("extensionsDir=".length());
+                	try {
+                		oclExtensionsDir = Paths.get(value);
+                	} catch (InvalidPathException e) {
+                		System.err.println("Invalid path " + StringUtil.inQuotes(value) + " for OCL extensions directory specified.");
+                		System.exit(1);
+                	}
+                } else if (arg.equals("nr")) {
                     suppressWarningsAboutMissingReadlineLibrary = true;
                 } else if (arg.equals("q")) {
                     Options.quiet = true;
@@ -441,7 +469,14 @@ public class Options {
         }
         
         setLastDirectory(homeDir);
-		pluginDir = homeDir.resolve("lib").resolve("plugins");
+		// Both directories default to a location below the home directory, but
+		// can be overridden independently via -pluginDir / -extensionsDir.
+		if (pluginDir == null) {
+			pluginDir = homeDir.resolve("lib").resolve("plugins");
+		}
+		if (oclExtensionsDir == null) {
+			oclExtensionsDir = homeDir.resolve("oclextensions");
+		}
 
         if (quiet && (specFilename == null || cmdFilename == null) ) {
 			System.err

--- a/use-core/src/test/java/org/tzi/use/config/OptionsDirectoryArgsTest.java
+++ b/use-core/src/test/java/org/tzi/use/config/OptionsDirectoryArgsTest.java
@@ -1,6 +1,6 @@
 /*
  * USE - UML based specification environment
- * Copyright (C) 1999-2004 Mark Richters, University of Bremen
+ * Copyright (C) 1999-2025 University of Bremen & University of Applied Sciences Hamburg
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -39,7 +39,6 @@ import org.junit.jupiter.api.Test;
  * applied and that each directory can be overridden independently with a
  * startup argument ({@code -pluginDir=} and {@code -extensionsDir=}).</p>
  *
- * @author Claude
  */
 public class OptionsDirectoryArgsTest {
 

--- a/use-core/src/test/java/org/tzi/use/config/OptionsDirectoryArgsTest.java
+++ b/use-core/src/test/java/org/tzi/use/config/OptionsDirectoryArgsTest.java
@@ -1,0 +1,117 @@
+/*
+ * USE - UML based specification environment
+ * Copyright (C) 1999-2004 Mark Richters, University of Bremen
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+package org.tzi.use.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Properties;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for the configurable directories for plugins and OCL extensions
+ * (issue #20).
+ *
+ * <p>By default both directories are derived from the USE home directory
+ * ({@code -H}): plugins live in {@code <home>/lib/plugins} and OCL extensions
+ * in {@code <home>/oclextensions}. These tests verify that both defaults are
+ * applied and that each directory can be overridden independently with a
+ * startup argument ({@code -pluginDir=} and {@code -extensionsDir=}).</p>
+ *
+ * @author Claude
+ */
+public class OptionsDirectoryArgsTest {
+
+    private Properties savedSystemProperties;
+
+    @BeforeEach
+    public void setUp() {
+        // processArgs() augments the global system properties; remember them
+        // so we can restore them and keep the test isolated.
+        savedSystemProperties = (Properties) System.getProperties().clone();
+        Options.resetOptions();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        Options.resetOptions();
+        System.setProperties(savedSystemProperties);
+    }
+
+    private Path home() {
+        return Paths.get(System.getProperty("java.io.tmpdir"), "use-home-under-test");
+    }
+
+    @Test
+    public void pluginDirDefaultsToHomeLibPlugins() {
+        Path home = home();
+        Options.processArgs(new String[] { "-H=" + home, "-c" });
+        assertEquals(home.resolve("lib").resolve("plugins"), Options.pluginDir,
+                "plugin directory must default to <home>/lib/plugins");
+    }
+
+    @Test
+    public void extensionsDirDefaultsToHomeOclextensions() {
+        Path home = home();
+        Options.processArgs(new String[] { "-H=" + home, "-c" });
+        assertEquals(home.resolve("oclextensions"), Options.oclExtensionsDir,
+                "OCL extensions directory must default to <home>/oclextensions");
+    }
+
+    @Test
+    public void pluginDirCanBeOverridden() {
+        Path home = home();
+        Path custom = Paths.get(System.getProperty("java.io.tmpdir"), "custom-plugins");
+        Options.processArgs(new String[] { "-H=" + home, "-pluginDir=" + custom, "-c" });
+        assertEquals(custom, Options.pluginDir,
+                "-pluginDir must override the plugin directory");
+        assertEquals(home.resolve("oclextensions"), Options.oclExtensionsDir,
+                "overriding the plugin directory must not affect the extensions directory");
+    }
+
+    @Test
+    public void extensionsDirCanBeOverridden() {
+        Path home = home();
+        Path custom = Paths.get(System.getProperty("java.io.tmpdir"), "custom-extensions");
+        Options.processArgs(new String[] { "-H=" + home, "-extensionsDir=" + custom, "-c" });
+        assertEquals(custom, Options.oclExtensionsDir,
+                "-extensionsDir must override the OCL extensions directory");
+        assertEquals(home.resolve("lib").resolve("plugins"), Options.pluginDir,
+                "overriding the extensions directory must not affect the plugin directory");
+    }
+
+    @Test
+    public void bothDirectoriesCanBeOverriddenIndependentlyOfHome() {
+        Path home = home();
+        Path customPlugins = Paths.get(System.getProperty("java.io.tmpdir"), "p");
+        Path customExtensions = Paths.get(System.getProperty("java.io.tmpdir"), "e");
+        Options.processArgs(new String[] {
+                "-H=" + home,
+                "-pluginDir=" + customPlugins,
+                "-extensionsDir=" + customExtensions,
+                "-c" });
+        assertEquals(customPlugins, Options.pluginDir);
+        assertEquals(customExtensions, Options.oclExtensionsDir);
+    }
+}

--- a/use-core/src/test/java/org/tzi/use/config/OptionsDirectoryArgsTest.java
+++ b/use-core/src/test/java/org/tzi/use/config/OptionsDirectoryArgsTest.java
@@ -1,6 +1,6 @@
 /*
  * USE - UML based specification environment
- * Copyright (C) 1999-2025 University of Bremen & University of Applied Sciences Hamburg
+ * Copyright (C) 1999-2026 University of Bremen & University of Applied Sciences Hamburg
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -39,6 +39,8 @@ import org.junit.jupiter.api.Test;
  * applied and that each directory can be overridden independently with a
  * startup argument ({@code -pluginDir=} and {@code -extensionsDir=}).</p>
  *
+ * @author Cansin Yildiz
+ * @author Claude
  */
 public class OptionsDirectoryArgsTest {
 

--- a/use-gui/src/main/java/org/tzi/use/main/gui/fx/JavaFXAppLauncher.java
+++ b/use-gui/src/main/java/org/tzi/use/main/gui/fx/JavaFXAppLauncher.java
@@ -61,7 +61,7 @@ public class JavaFXAppLauncher extends Application {
 
     private void initExtensions() {
         if (!Options.disableExtensions) {
-            ExtensionManager.EXTENSIONS_FOLDER = Options.homeDir + Options.FILE_SEPARATOR + "oclextensions";
+            ExtensionManager.EXTENSIONS_FOLDER = Options.oclExtensionsDir.toString();
             ExtensionManager.getInstance().loadExtensions();
         }
     }

--- a/use-gui/src/main/java/org/tzi/use/main/gui/swing/MainSwing.java
+++ b/use-gui/src/main/java/org/tzi/use/main/gui/swing/MainSwing.java
@@ -42,7 +42,7 @@ public class MainSwing {
         MSystem system = null;
 
         if (!Options.disableExtensions) {
-            ExtensionManager.EXTENSIONS_FOLDER = Options.homeDir + Options.FILE_SEPARATOR + "oclextensions";
+            ExtensionManager.EXTENSIONS_FOLDER = Options.oclExtensionsDir.toString();
             ExtensionManager.getInstance().loadExtensions();
         }
 


### PR DESCRIPTION
## Summary

Fixes #20.

USE resolved the plugin directory and the OCL extensions directory from fixed
locations under the home directory (`<home>/lib/plugins` and
`<home>/oclextensions`). This forced every environment (unit tests, integration
tests, …) to be aligned to that fixed layout.

This PR adds two startup arguments to override these directories independently:

- `-pluginDir=<path>` — directory to load plugins from (default: `<home>/lib/plugins`)
- `-extensionsDir=<path>` — directory to load OCL extensions from (default: `<home>/oclextensions`)

## Changes

- `Options.processArgs` parses `-pluginDir` and `-extensionsDir` into
  `Options.pluginDir` / `Options.oclExtensionsDir`. The home-relative defaults are
  applied only when the argument is not given, so behavior is unchanged when the
  new arguments are absent.
- The Swing (`MainSwing`) and JavaFX (`JavaFXAppLauncher`) launchers now read the
  configured OCL extensions directory from `Options.oclExtensionsDir` instead of
  recomputing `<home>/oclextensions`. Plugins were already loaded from
  `Options.pluginDir`.
- `use -h` documents both new arguments.

## Backward compatibility

With neither argument given, `-pluginDir` defaults to `<home>/lib/plugins` and
`-extensionsDir` to `<home>/oclextensions` — identical to the previous behavior.

## Testing

- New `OptionsDirectoryArgsTest` (use-core) verifies the defaults and that each
  directory can be overridden independently of `-H`.
- `use-core` tests and the `use-gui` `ShellIT` integration suite (129 tests) pass.
- Manual end-to-end check: running USE headless with
  `-extensionsDir=/tmp/X -pluginDir=/tmp/Y` makes the extension and plugin loaders
  report those exact paths, confirming the overrides take effect.

## Possible follow-up (not in this PR)

The `ShellIT` workaround referenced in the issue (needing an empty
`use-core/.../lib/plugins`) can now be simplified by passing `-pluginDir` at a
temporary empty directory. Left out here to keep the PR focused.