### PR TITLE
Do not record recent files in test mode (#50)

### DIFF
--- a/use-core/src/main/java/org/tzi/use/config/RecentItems.java
+++ b/use-core/src/main/java/org/tzi/use/config/RecentItems.java
@@ -54,6 +54,13 @@ public class RecentItems
     
     public void push(String item)
     {
+        // Issue #50: while USE runs in test mode (the -t argument), e.g. during
+        // integration tests, opened files must not be recorded as recent items,
+        // otherwise they would push out the user's own entries.
+        if (Options.testMode) {
+            return;
+        }
+
         m_items.remove(item);
         m_items.add(0, item);
         

--- a/use-core/src/test/java/org/tzi/use/config/RecentItemsTest.java
+++ b/use-core/src/test/java/org/tzi/use/config/RecentItemsTest.java
@@ -1,0 +1,82 @@
+/*
+ * USE - UML based specification environment
+ * Copyright (C) 1999-2012 Mark Richters, University of Bremen
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+package org.tzi.use.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.prefs.BackingStoreException;
+import java.util.prefs.Preferences;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that recent items are not recorded while USE runs in test mode.
+ *
+ * <p>When integration tests run, the files they open must not be added to the
+ * user's recent files list, otherwise they would push out the user's own
+ * entries (issue #50). This is controlled by {@link Options#testMode}.</p>
+ *
+ * @author Claude
+ */
+public class RecentItemsTest {
+
+    /** An isolated preferences node, kept separate from the real recent files. */
+    private Preferences node;
+
+    @BeforeEach
+    public void setUp() throws BackingStoreException {
+        Options.resetOptions();
+        node = Preferences.userRoot().node("/org/tzi/use/test/recentitems");
+        node.clear();
+    }
+
+    @AfterEach
+    public void tearDown() throws BackingStoreException {
+        node.clear();
+        Options.resetOptions();
+    }
+
+    @Test
+    public void pushIsIgnoredInTestMode() {
+        RecentItems items = new RecentItems(5, node);
+        assertTrue(items.isEmpty(), "precondition: no recent items");
+
+        Options.testMode = true;
+        items.push("/tmp/integration-test-file.use");
+
+        assertTrue(items.isEmpty(),
+                "In test mode, opening files must not be recorded as recent items.");
+    }
+
+    @Test
+    public void pushRecordsWhenNotInTestMode() {
+        RecentItems items = new RecentItems(5, node);
+
+        Options.testMode = false;
+        items.push("/tmp/user-file.use");
+
+        assertEquals(1, items.size(),
+                "Outside test mode, recent items must still be recorded as before.");
+        assertEquals("/tmp/user-file.use", items.peek());
+    }
+}

--- a/use-core/src/test/java/org/tzi/use/config/RecentItemsTest.java
+++ b/use-core/src/test/java/org/tzi/use/config/RecentItemsTest.java
@@ -1,6 +1,6 @@
 /*
  * USE - UML based specification environment
- * Copyright (C) 1999-2012 Mark Richters, University of Bremen
+ * Copyright (C) 1999-2025 University of Bremen & University of Applied Sciences Hamburg
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -36,7 +36,6 @@ import org.junit.jupiter.api.Test;
  * user's recent files list, otherwise they would push out the user's own
  * entries (issue #50). This is controlled by {@link Options#testMode}.</p>
  *
- * @author Claude
  */
 public class RecentItemsTest {
 

--- a/use-core/src/test/java/org/tzi/use/config/RecentItemsTest.java
+++ b/use-core/src/test/java/org/tzi/use/config/RecentItemsTest.java
@@ -1,6 +1,6 @@
 /*
  * USE - UML based specification environment
- * Copyright (C) 1999-2025 University of Bremen & University of Applied Sciences Hamburg
+ * Copyright (C) 1999-2026 University of Bremen & University of Applied Sciences Hamburg
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -36,6 +36,8 @@ import org.junit.jupiter.api.Test;
  * user's recent files list, otherwise they would push out the user's own
  * entries (issue #50). This is controlled by {@link Options#testMode}.</p>
  *
+ * @author Cansin Yildiz
+ * @author Claude
  */
 public class RecentItemsTest {
 


### PR DESCRIPTION
## Summary

Fixes #50.

Running USE in test mode (`-t`) — e.g. the `ShellIT` integration tests — opened
files through the shell and recorded them in the user's recent files list,
pushing out the user's own entries.

## Fix

`RecentItems.push(...)` now returns early when `Options.testMode` is set, so
nothing is recorded while USE runs in test mode. `RecentItems` and `Options` are
in the same package, and `recentSpecifications` is the only `RecentItems`
instance, so this single guard covers every path that records recent files (the
shell `open` command, and the spec-file push in the launchers — the latter was
already guarded the same way).

The user's recent files (stored in Java Preferences) are therefore left untouched
by the test suite.

## Testing

- New `RecentItemsTest` (use-core): `push` is ignored in test mode and still
  records normally otherwise.
- The full `use-core` suite and the 129 `ShellIT` integration tests pass. No
  integration test depends on `reopen` / recent files.