### PR TITLE
Introduce UserOutput foundation (towards #60)

### DIFF
--- a/use-core/src/main/java/org/tzi/use/util/CollectingUserOutput.java
+++ b/use-core/src/main/java/org/tzi/use/util/CollectingUserOutput.java
@@ -1,6 +1,6 @@
 /*
  * USE - UML based specification environment
- * Copyright (C) 1999-2004 Mark Richters, University of Bremen
+ * Copyright (C) 1999-2025 University of Bremen & University of Applied Sciences Hamburg
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -26,7 +26,6 @@ import java.util.Map;
  * A {@link UserOutput} that collects all output in memory. Useful for tests and
  * for capturing output before forwarding it somewhere else.
  *
- * @author Claude
  */
 public class CollectingUserOutput implements UserOutput {
 

--- a/use-core/src/main/java/org/tzi/use/util/CollectingUserOutput.java
+++ b/use-core/src/main/java/org/tzi/use/util/CollectingUserOutput.java
@@ -1,6 +1,6 @@
 /*
  * USE - UML based specification environment
- * Copyright (C) 1999-2025 University of Bremen & University of Applied Sciences Hamburg
+ * Copyright (C) 1999-2026 University of Bremen & University of Applied Sciences Hamburg
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -26,6 +26,8 @@ import java.util.Map;
  * A {@link UserOutput} that collects all output in memory. Useful for tests and
  * for capturing output before forwarding it somewhere else.
  *
+ * @author Cansin Yildiz
+ * @author Claude
  */
 public class CollectingUserOutput implements UserOutput {
 

--- a/use-core/src/main/java/org/tzi/use/util/CollectingUserOutput.java
+++ b/use-core/src/main/java/org/tzi/use/util/CollectingUserOutput.java
@@ -1,0 +1,52 @@
+/*
+ * USE - UML based specification environment
+ * Copyright (C) 1999-2004 Mark Richters, University of Bremen
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+package org.tzi.use.util;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+/**
+ * A {@link UserOutput} that collects all output in memory. Useful for tests and
+ * for capturing output before forwarding it somewhere else.
+ *
+ * @author Claude
+ */
+public class CollectingUserOutput implements UserOutput {
+
+    private final StringBuilder all = new StringBuilder();
+    private final Map<OutputLevel, StringBuilder> byLevel = new EnumMap<>(OutputLevel.class);
+
+    @Override
+    public void print(OutputLevel level, String message) {
+        all.append(message);
+        byLevel.computeIfAbsent(level, l -> new StringBuilder()).append(message);
+    }
+
+    /** All collected output across every level, in the order it was produced. */
+    public String getOutput() {
+        return all.toString();
+    }
+
+    /** The collected output for a single {@code level}. */
+    public String getOutput(OutputLevel level) {
+        StringBuilder sb = byLevel.get(level);
+        return sb == null ? "" : sb.toString();
+    }
+}

--- a/use-core/src/main/java/org/tzi/use/util/NullUserOutput.java
+++ b/use-core/src/main/java/org/tzi/use/util/NullUserOutput.java
@@ -1,0 +1,33 @@
+/*
+ * USE - UML based specification environment
+ * Copyright (C) 1999-2004 Mark Richters, University of Bremen
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+package org.tzi.use.util;
+
+/**
+ * A {@link UserOutput} that discards all output.
+ *
+ * @author Claude
+ */
+public final class NullUserOutput implements UserOutput {
+
+    @Override
+    public void print(OutputLevel level, String message) {
+        // discard
+    }
+}

--- a/use-core/src/main/java/org/tzi/use/util/NullUserOutput.java
+++ b/use-core/src/main/java/org/tzi/use/util/NullUserOutput.java
@@ -1,6 +1,6 @@
 /*
  * USE - UML based specification environment
- * Copyright (C) 1999-2004 Mark Richters, University of Bremen
+ * Copyright (C) 1999-2025 University of Bremen & University of Applied Sciences Hamburg
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -22,7 +22,6 @@ package org.tzi.use.util;
 /**
  * A {@link UserOutput} that discards all output.
  *
- * @author Claude
  */
 public final class NullUserOutput implements UserOutput {
 

--- a/use-core/src/main/java/org/tzi/use/util/NullUserOutput.java
+++ b/use-core/src/main/java/org/tzi/use/util/NullUserOutput.java
@@ -1,6 +1,6 @@
 /*
  * USE - UML based specification environment
- * Copyright (C) 1999-2025 University of Bremen & University of Applied Sciences Hamburg
+ * Copyright (C) 1999-2026 University of Bremen & University of Applied Sciences Hamburg
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -22,6 +22,8 @@ package org.tzi.use.util;
 /**
  * A {@link UserOutput} that discards all output.
  *
+ * @author Cansin Yildiz
+ * @author Claude
  */
 public final class NullUserOutput implements UserOutput {
 

--- a/use-core/src/main/java/org/tzi/use/util/OutputLevel.java
+++ b/use-core/src/main/java/org/tzi/use/util/OutputLevel.java
@@ -1,0 +1,43 @@
+/*
+ * USE - UML based specification environment
+ * Copyright (C) 1999-2004 Mark Richters, University of Bremen
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+package org.tzi.use.util;
+
+/**
+ * The level of a piece of {@link UserOutput} meant for the USE user.
+ *
+ * <p>This is intentionally separate from developer-facing logging (see issue
+ * #60): it describes <em>what kind</em> of user output is produced, so that
+ * different output targets can render or route it accordingly (e.g. errors and
+ * warnings to an error stream, warnings highlighted, ...).</p>
+ *
+ * @author Claude
+ */
+public enum OutputLevel {
+    /** Regular output that is the result the user asked for. */
+    NORMAL,
+    /** Additional, informational output. */
+    INFO,
+    /** A warning the user should be aware of. */
+    WARN,
+    /** An error reported to the user. */
+    ERROR,
+    /** Fine-grained trace output for following what USE is doing. */
+    TRACE
+}

--- a/use-core/src/main/java/org/tzi/use/util/OutputLevel.java
+++ b/use-core/src/main/java/org/tzi/use/util/OutputLevel.java
@@ -1,6 +1,6 @@
 /*
  * USE - UML based specification environment
- * Copyright (C) 1999-2025 University of Bremen & University of Applied Sciences Hamburg
+ * Copyright (C) 1999-2026 University of Bremen & University of Applied Sciences Hamburg
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -27,6 +27,8 @@ package org.tzi.use.util;
  * different output targets can render or route it accordingly (e.g. errors and
  * warnings to an error stream, warnings highlighted, ...).</p>
  *
+ * @author Cansin Yildiz
+ * @author Claude
  */
 public enum OutputLevel {
     /** Regular output that is the result the user asked for. */

--- a/use-core/src/main/java/org/tzi/use/util/OutputLevel.java
+++ b/use-core/src/main/java/org/tzi/use/util/OutputLevel.java
@@ -1,6 +1,6 @@
 /*
  * USE - UML based specification environment
- * Copyright (C) 1999-2004 Mark Richters, University of Bremen
+ * Copyright (C) 1999-2025 University of Bremen & University of Applied Sciences Hamburg
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -27,7 +27,6 @@ package org.tzi.use.util;
  * different output targets can render or route it accordingly (e.g. errors and
  * warnings to an error stream, warnings highlighted, ...).</p>
  *
- * @author Claude
  */
 public enum OutputLevel {
     /** Regular output that is the result the user asked for. */

--- a/use-core/src/main/java/org/tzi/use/util/StreamUserOutput.java
+++ b/use-core/src/main/java/org/tzi/use/util/StreamUserOutput.java
@@ -1,6 +1,6 @@
 /*
  * USE - UML based specification environment
- * Copyright (C) 1999-2025 University of Bremen & University of Applied Sciences Hamburg
+ * Copyright (C) 1999-2026 University of Bremen & University of Applied Sciences Hamburg
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -26,6 +26,8 @@ import java.util.Objects;
  * A {@link UserOutput} that writes to {@link PrintStream}s. Warnings and errors
  * are written to the error stream, everything else to the normal stream.
  *
+ * @author Cansin Yildiz
+ * @author Claude
  */
 public class StreamUserOutput implements UserOutput {
 

--- a/use-core/src/main/java/org/tzi/use/util/StreamUserOutput.java
+++ b/use-core/src/main/java/org/tzi/use/util/StreamUserOutput.java
@@ -1,6 +1,6 @@
 /*
  * USE - UML based specification environment
- * Copyright (C) 1999-2004 Mark Richters, University of Bremen
+ * Copyright (C) 1999-2025 University of Bremen & University of Applied Sciences Hamburg
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -26,7 +26,6 @@ import java.util.Objects;
  * A {@link UserOutput} that writes to {@link PrintStream}s. Warnings and errors
  * are written to the error stream, everything else to the normal stream.
  *
- * @author Claude
  */
 public class StreamUserOutput implements UserOutput {
 

--- a/use-core/src/main/java/org/tzi/use/util/StreamUserOutput.java
+++ b/use-core/src/main/java/org/tzi/use/util/StreamUserOutput.java
@@ -1,0 +1,59 @@
+/*
+ * USE - UML based specification environment
+ * Copyright (C) 1999-2004 Mark Richters, University of Bremen
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+package org.tzi.use.util;
+
+import java.io.PrintStream;
+import java.util.Objects;
+
+/**
+ * A {@link UserOutput} that writes to {@link PrintStream}s. Warnings and errors
+ * are written to the error stream, everything else to the normal stream.
+ *
+ * @author Claude
+ */
+public class StreamUserOutput implements UserOutput {
+
+    private final PrintStream normalStream;
+    private final PrintStream errorStream;
+
+    /**
+     * @param normalStream stream for {@code NORMAL}, {@code INFO} and {@code TRACE} output
+     * @param errorStream  stream for {@code WARN} and {@code ERROR} output
+     */
+    public StreamUserOutput(PrintStream normalStream, PrintStream errorStream) {
+        this.normalStream = Objects.requireNonNull(normalStream);
+        this.errorStream = Objects.requireNonNull(errorStream);
+    }
+
+    /** Writes all levels to the same stream. */
+    public StreamUserOutput(PrintStream stream) {
+        this(stream, stream);
+    }
+
+    @Override
+    public void print(OutputLevel level, String message) {
+        streamFor(level).print(message);
+    }
+
+    private PrintStream streamFor(OutputLevel level) {
+        return (level == OutputLevel.WARN || level == OutputLevel.ERROR)
+                ? errorStream : normalStream;
+    }
+}

--- a/use-core/src/main/java/org/tzi/use/util/UserOutput.java
+++ b/use-core/src/main/java/org/tzi/use/util/UserOutput.java
@@ -1,6 +1,6 @@
 /*
  * USE - UML based specification environment
- * Copyright (C) 1999-2004 Mark Richters, University of Bremen
+ * Copyright (C) 1999-2025 University of Bremen & University of Applied Sciences Hamburg
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -33,7 +33,6 @@ package org.tzi.use.util;
  * <p>Implementations only have to provide {@link #print(OutputLevel, String)};
  * the {@code println} and per-level convenience methods are derived from it.</p>
  *
- * @author Claude
  */
 public interface UserOutput {
 

--- a/use-core/src/main/java/org/tzi/use/util/UserOutput.java
+++ b/use-core/src/main/java/org/tzi/use/util/UserOutput.java
@@ -1,0 +1,95 @@
+/*
+ * USE - UML based specification environment
+ * Copyright (C) 1999-2004 Mark Richters, University of Bremen
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+package org.tzi.use.util;
+
+/**
+ * Abstraction for output that is meant for the USE <em>user</em>, as opposed to
+ * developer-facing logging.
+ *
+ * <p>This is the foundation for unifying USE's output handling (issue #60).
+ * Instead of statically writing to {@code System.out}/{@code System.err} or the
+ * static {@link Log}, code that produces user output should be given a
+ * {@code UserOutput} instance. This separates user output from developer
+ * logging, allows multiple output targets (e.g. shell and log window) and
+ * allows decorated output (e.g. warnings in a different color).</p>
+ *
+ * <p>Implementations only have to provide {@link #print(OutputLevel, String)};
+ * the {@code println} and per-level convenience methods are derived from it.</p>
+ *
+ * @author Claude
+ */
+public interface UserOutput {
+
+    /**
+     * Outputs {@code message} at the given {@code level}. This is the single
+     * method implementations must provide.
+     */
+    void print(OutputLevel level, String message);
+
+    /** Outputs {@code message} followed by a line separator at {@code level}. */
+    default void println(OutputLevel level, String message) {
+        print(level, message + System.lineSeparator());
+    }
+
+    /** Outputs an empty line at {@code level}. */
+    default void println(OutputLevel level) {
+        print(level, System.lineSeparator());
+    }
+
+    default void printNormal(String message)   { print(OutputLevel.NORMAL, message); }
+    default void printlnNormal(String message) { println(OutputLevel.NORMAL, message); }
+    default void printlnNormal()               { println(OutputLevel.NORMAL); }
+
+    default void printInfo(String message)     { print(OutputLevel.INFO, message); }
+    default void printlnInfo(String message)   { println(OutputLevel.INFO, message); }
+
+    default void printWarn(String message)     { print(OutputLevel.WARN, message); }
+    default void printlnWarn(String message)   { println(OutputLevel.WARN, message); }
+
+    default void printError(String message)    { print(OutputLevel.ERROR, message); }
+    default void printlnError(String message)  { println(OutputLevel.ERROR, message); }
+
+    default void printTrace(String message)    { print(OutputLevel.TRACE, message); }
+    default void printlnTrace(String message)  { println(OutputLevel.TRACE, message); }
+
+    /**
+     * A {@code UserOutput} that discards everything. Useful where no user output
+     * is desired.
+     */
+    static UserOutput getSilentOutput() {
+        return new NullUserOutput();
+    }
+
+    /**
+     * The default {@code UserOutput}, writing normal output to {@code System.out}
+     * and warnings/errors to {@code System.err}.
+     */
+    static UserOutput getDefaultOutput() {
+        return new StreamUserOutput(System.out, System.err);
+    }
+
+    /**
+     * A {@code UserOutput} that collects everything in memory. Useful for tests
+     * and for capturing output.
+     */
+    static CollectingUserOutput createCollectingOutput() {
+        return new CollectingUserOutput();
+    }
+}

--- a/use-core/src/main/java/org/tzi/use/util/UserOutput.java
+++ b/use-core/src/main/java/org/tzi/use/util/UserOutput.java
@@ -1,6 +1,6 @@
 /*
  * USE - UML based specification environment
- * Copyright (C) 1999-2025 University of Bremen & University of Applied Sciences Hamburg
+ * Copyright (C) 1999-2026 University of Bremen & University of Applied Sciences Hamburg
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -33,6 +33,8 @@ package org.tzi.use.util;
  * <p>Implementations only have to provide {@link #print(OutputLevel, String)};
  * the {@code println} and per-level convenience methods are derived from it.</p>
  *
+ * @author Cansin Yildiz
+ * @author Claude
  */
 public interface UserOutput {
 

--- a/use-core/src/test/java/org/tzi/use/util/UserOutputTest.java
+++ b/use-core/src/test/java/org/tzi/use/util/UserOutputTest.java
@@ -1,6 +1,6 @@
 /*
  * USE - UML based specification environment
- * Copyright (C) 1999-2004 Mark Richters, University of Bremen
+ * Copyright (C) 1999-2025 University of Bremen & University of Applied Sciences Hamburg
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -32,7 +32,6 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests for the {@link UserOutput} abstraction (issue #60).
  *
- * @author Claude
  */
 public class UserOutputTest {
 

--- a/use-core/src/test/java/org/tzi/use/util/UserOutputTest.java
+++ b/use-core/src/test/java/org/tzi/use/util/UserOutputTest.java
@@ -1,0 +1,111 @@
+/*
+ * USE - UML based specification environment
+ * Copyright (C) 1999-2004 Mark Richters, University of Bremen
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+package org.tzi.use.util;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for the {@link UserOutput} abstraction (issue #60).
+ *
+ * @author Claude
+ */
+public class UserOutputTest {
+
+    private static final String NL = System.lineSeparator();
+
+    @Test
+    public void collectingCapturesAllOutputInOrder() {
+        CollectingUserOutput out = UserOutput.createCollectingOutput();
+        out.printlnNormal("hello");
+        out.printlnError("oops");
+        assertEquals("hello" + NL + "oops" + NL, out.getOutput());
+    }
+
+    @Test
+    public void collectingSeparatesOutputByLevel() {
+        CollectingUserOutput out = new CollectingUserOutput();
+        out.printlnNormal("n");
+        out.printlnWarn("w");
+        out.printlnError("e");
+        assertEquals("n" + NL, out.getOutput(OutputLevel.NORMAL));
+        assertEquals("w" + NL, out.getOutput(OutputLevel.WARN));
+        assertEquals("e" + NL, out.getOutput(OutputLevel.ERROR));
+        assertEquals("", out.getOutput(OutputLevel.INFO));
+    }
+
+    @Test
+    public void convenienceMethodsUseTheMatchingLevel() {
+        CollectingUserOutput out = new CollectingUserOutput();
+        out.printInfo("i");
+        out.printTrace("t");
+        assertEquals("i", out.getOutput(OutputLevel.INFO));
+        assertEquals("t", out.getOutput(OutputLevel.TRACE));
+    }
+
+    @Test
+    public void streamRoutesNormalToOutAndWarningsErrorsToErr() {
+        ByteArrayOutputStream outBuf = new ByteArrayOutputStream();
+        ByteArrayOutputStream errBuf = new ByteArrayOutputStream();
+        UserOutput out = new StreamUserOutput(
+                new PrintStream(outBuf, true, StandardCharsets.UTF_8),
+                new PrintStream(errBuf, true, StandardCharsets.UTF_8));
+
+        out.printNormal("N");
+        out.printInfo("I");
+        out.printTrace("T");
+        out.printWarn("W");
+        out.printError("E");
+
+        assertEquals("NIT", outBuf.toString(StandardCharsets.UTF_8));
+        assertEquals("WE", errBuf.toString(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void printlnAppendsLineSeparator() {
+        ByteArrayOutputStream buf = new ByteArrayOutputStream();
+        UserOutput out = new StreamUserOutput(new PrintStream(buf, true, StandardCharsets.UTF_8));
+        out.printlnNormal("x");
+        assertEquals("x" + NL, buf.toString(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void silentOutputDiscardsEverythingWithoutError() {
+        UserOutput out = UserOutput.getSilentOutput();
+        assertDoesNotThrow(() -> {
+            out.printlnNormal("ignored");
+            out.printlnError("ignored");
+        });
+    }
+
+    @Test
+    public void factoriesReturnUsableInstances() {
+        assertNotNull(UserOutput.getDefaultOutput());
+        assertNotNull(UserOutput.getSilentOutput());
+        assertNotNull(UserOutput.createCollectingOutput());
+    }
+}

--- a/use-core/src/test/java/org/tzi/use/util/UserOutputTest.java
+++ b/use-core/src/test/java/org/tzi/use/util/UserOutputTest.java
@@ -1,6 +1,6 @@
 /*
  * USE - UML based specification environment
- * Copyright (C) 1999-2025 University of Bremen & University of Applied Sciences Hamburg
+ * Copyright (C) 1999-2026 University of Bremen & University of Applied Sciences Hamburg
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -32,6 +32,8 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests for the {@link UserOutput} abstraction (issue #60).
  *
+ * @author Cansin Yildiz
+ * @author Claude
  */
 public class UserOutputTest {
 


### PR DESCRIPTION
## Summary

A first, additive increment towards #60 (unify user and developer output).

#60 proposes separating output meant for the USE **user** from developer
logging, replacing the tangle of the static `Log`, `USEWriter`, raw
`System.out`/`System.err` and ad-hoc `PrintWriter` arguments. That's a large
migration; this PR lands just the **foundation** so it can be adopted
incrementally.

**This PR does not close #60** — it introduces the abstraction the issue
proposes, with no migration and no behavior change.

## What's added (`org.tzi.use.util`, all new)

- `OutputLevel` — `NORMAL`, `INFO`, `WARN`, `ERROR`, `TRACE`.
- `UserOutput` — interface with a single `print(OutputLevel, String)` that drives
  the derived `println` and per-level convenience methods
  (`printlnNormal`/`printlnInfo`/`printlnWarn`/`printlnError`/`printlnTrace`),
  plus factories for the default / silent / collecting outputs.
- `StreamUserOutput` — writes to print streams (`WARN`/`ERROR` → error stream,
  the rest → normal stream).
- `CollectingUserOutput` — collects output in memory, per level (tests/capture).
- `NullUserOutput` — discards output.

## Testing

`UserOutputTest` covers stream routing, per-level separation, the convenience
methods, `println` line separators, the silent output, and the factories. The
full `use-core` suite (including the ArchUnit cyclic-dependency checks) passes.

## Suggested next steps (separate PRs)

Adopt `UserOutput` where a `PrintWriter` is currently threaded through (e.g.
`USECompiler`), then migrate `Log`'s user-facing calls, keeping developer
logging on a logging framework.