### PR TITLE
build: pin maven-compiler-plugin to 3.15.0 for JPMS module resolution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,4 +19,16 @@
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.15.0</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 </project>

--- a/use-gui/pom.xml
+++ b/use-gui/pom.xml
@@ -187,7 +187,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.13.0</version>
                 <configuration>
                     <annotationProcessorPaths>
                         <path>


### PR DESCRIPTION
## Problem
A clean `mvn package` fails at `use-core` on the Maven thatUbuntu 24.04 LTS
ships via apt (3.8.7):
```
    [ERROR] maven-compiler-plugin:3.1:compile (default-compile) @ use-core
    module-info.java:[2,19] module not found: antlr.runtime
    module-info.java:[3,29] module not found: org.eclipse.jdt.annotation
    module-info.java:[6,24] module not found: com.google.common
    module-info.java:[7,17] module not found: vtd.xml
    module-info.java:[9,23] module not found: org.jruby.dist
    module-info.java:[10,14] module not found: combinatoricslib
```
## Root cause
`use-core` has a JPMS `module-info.java` with `requires` directives. The parent
pom never pined `maven-compiler-plugin`, so its version is whatever the running
Maven defaults to:

| Maven | default compiler plugin | module path? | result |
|------|------------------------|--------------|--------|
| 3.8.7 (apt on Ubuntu 24.04 LTS) | **3.1** (2013, pre-JPMS) | no | **FAIL** |
| 3.9.16 (latest stable)          | 3.15.0| yes | OK |

Plugin 3.1 predates Java 9 modules and puts dependencies only on the classpath,
so none of the `requires` modules resolve. Build success depended entirely on
the contributor's local Maven version. `use-gui` already pins 3.13.0; `use-core`
inherited nothing.

## Reproduce
    sudo apt install maven   # Ubuntu 24.04 -> 3.8.7
    mvn -v# confirm 3.8.x
    mvn clean package        # FAILS: "module not found", via maven-compiler-plugin:3.1

## Fix
Pin `maven-compiler-plugin` to 3.15.0 in the parent pom `<pluginManagement>` (and remove the specific version in `use-gui`, so
every module inherits a module-aware compiler regardless of local Maven.

## Verification (all four executed)
| Maven | without pin | with pin |
|------|-------|-------|
| 3.8.7  | FAIL (compiler-plugin:3.1) | BUILD SUCCESS (3.15.0) |
| 3.9.16 | BUILD SUCCESS (3.15.0)     | BUILD SUCCESS (3.15.0) |

The pin is harmless on modern Maven as it only rescues the older Maven that
distros still ship.